### PR TITLE
Improved the i18n library

### DIFF
--- a/packages/dantalion-core/src/types/AffinityLevel.ts
+++ b/packages/dantalion-core/src/types/AffinityLevel.ts
@@ -9,4 +9,3 @@
  * | `3` | Fantastic!!! |
  */
 export type AffinityLevel = 0 | 1 | 2 | 3;
-export default undefined;

--- a/packages/dantalion-i18n/README.md
+++ b/packages/dantalion-i18n/README.md
@@ -80,6 +80,25 @@ The instance provides a set of functions that retrieve human-readable resources 
 - Type: `ResourcesAccessor<DetailsType, Communication>`
 - The [`Communication`](../dantalion-core#communication) type is a string literal union type provided by the `@kurone-kito/dantalion-core` library.
 
+### `createTAsync(lng?: string, addition?: i18next.ResourceLanguage | undefined): Promise<i18next.TFunction>`
+
+Create and initialize the i18next instance asynchronously
+
+#### Arguments
+
+| Name       | Type                       | Defaults    | Description                                  |
+| :--------- | :------------------------- | :---------- | :------------------------------------------- |
+| `lng`      | `string?`                  | (\*)        | The language to use                          |
+| `addition` | `i18next.ResourceLanguage` | `undefined` | Specify the additional resources if you need |
+
+(\*: If omitted, the language used is detected from the current environment.
+See: [useLocale()](#getlocale-string--undefined))
+
+#### Returns
+
+`Promise<i18next.TFunction>`:
+The i18next instance which already initialized the resources.
+
 ### `getDescriptionAsync(type?: string): Promise<DesctiptionsType | undefined>`
 
 Get the resources of the descriptions heading.

--- a/packages/dantalion-i18n/README.md
+++ b/packages/dantalion-i18n/README.md
@@ -92,27 +92,53 @@ Get the resources of the descriptions heading.
 
 Get the personality information.
 
-- `genius`: The types of personality.
-- Returns: The string that the personality information. If the omitted, it will be list of the available types.
+#### Arguments
+
+| Name     | Type                  | Defaults    | Description               |
+| :------- | :-------------------- | :---------- | :------------------------ |
+| `genius` | `Genius \| undefined` | `undefined` | The types of personality. |
+
+#### Returns
+
+`Promise<string>`:
+The string that the personality information as the Markdown format.
+
+If you specified the `undefined` value as an argument or omitted it,
+it would be a list of the available types.
 
 ### `getLocale(): string | undefined`
 
-It provides the appropriate locale information acquisition function according to the current environment.
+It provides the appropriate locale information acquisition function
+according to the current environment.
 
-For Node.js version 12.1.0 and later or web browsers, it depends on the [Intl API](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl)'s decision. If not, it determines by the environment variables.
+For Node.js version `12.1.0` and later or web browsers, it depends on the
+[Intl API](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl)'s
+decision. If not, it determines by the environment variables.
 
-- Arguments: _(None)_
-- Returns: The locale string e.g. `en-US.utf8` or undefined value.
+#### Arguments
+
+(None)
+
+#### Returns
+
+`string | undefined`: The locale string e.g. `en-US`.
+If it is not recognized correctly, it may return an undefined value.
 
 ### `getPersonalityMarkdownAsync(birth: string | number | Date): Promise<string>`
 
 Get the personality information corresponding to the specified birthday.
 
-- `birth`: Specify a birthday within the range from February 1, 1873,
-  to December 31, 2050.
-  Ignore the _time_ information.
-- Returns: The string that the personality information. If the date is over the range,
-  it will be error message.
+#### Arguments
+
+| Name    | Type                       | Defaults     | Description                                                                                                     |
+| :------ | :------------------------- | :----------- | :-------------------------------------------------------------------------------------------------------------- |
+| `birth` | `string \| number \| Date` | _(Required)_ | Specify a birthday within the range from February 1, 1873, to December 31, 2050. Ignore the _time_ information. |
+
+#### Returns
+
+`Promise<string>`:
+The string that the personality information as the Markdown format.
+If the date is over the range, it will be error message.
 
 ### `genius`
 

--- a/packages/dantalion-i18n/README.md
+++ b/packages/dantalion-i18n/README.md
@@ -318,3 +318,11 @@ interface VectorType {
 | `detail`   | `string`            | The detail.                                                            |
 | `name`     | `string`            | The resource name as a heading.                                        |
 | `strategy` | `readonly string[]` | The strategies for communicating with people of this personality type. |
+
+## See also
+
+- [i18next: internationalization-framework](https://www.i18next.com)
+
+## License
+
+MIT

--- a/packages/dantalion-i18n/README.md
+++ b/packages/dantalion-i18n/README.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD024 -->
+
 # 🦁 Dantalion: i18n resources library
 
 [![npm version](https://badge.fury.io/js/%40kurone-kito%2Fdantalion-i18n.svg)](https://badge.fury.io/js/%40kurone-kito%2Fdantalion-i18n)

--- a/packages/dantalion-i18n/README.md
+++ b/packages/dantalion-i18n/README.md
@@ -208,7 +208,7 @@ The instance provides a set of functions that retrieve human-readable resources 
 - Type: `ResourcesAccessor<VectorType, Vector>`
 - The [`Vector`](../dantalion-core#vector) type is a string literal union type provided by the `@kurone-kito/dantalion-core` library.
 
-## Types (for TypeScript)
+## Type definitions (for TypeScript)
 
 The strings contained in the object are in Markdown format. In the
 case of an array of strings, the elements separate for each paragraph.
@@ -240,6 +240,33 @@ interface DesctiptionsType {
 | `personality` | `string` | The title of personality.                          |
 | `strategy`    | `string` | The strategy.                                      |
 | `weak`        | `string` | The weak points.                                   |
+
+### `DetailAccessor<T, K, D>`
+
+The type definition with a function to
+access a resource of the specific category.
+
+```ts
+interface DetailAccessor<
+  T extends i18next.TFunctionResult,
+  K extends string = string,
+  D extends DetailsBaseType | string = DetailsBaseType
+> {
+  getByKey(key: K): T;
+  getCategoryDetail(): D;
+}
+```
+
+| Type | Constraint                  | Description                                                |
+| :--- | :-------------------------- | :--------------------------------------------------------- |
+| `T`  | `i18next.TFunctionResult`   | The type of resource as a return value.                    |
+| `K`  | `string`                    | The type for the resource key.                             |
+| `D`  | `DetailsBaseType \| string` | The type of resource as a return value of category detail. |
+
+| Method definition        | Description                                                                |
+| :----------------------- | :------------------------------------------------------------------------- |
+| `getByKey(key: K): T`    | The function acquires the resource corresponding to the key.               |
+| `getCategoryDetail(): D` | The function acquires the resource corresponding to the specific category. |
 
 ### `DetailsBaseType`
 
@@ -320,7 +347,38 @@ interface PersonalityType {
 | `summary`  | `string`            | The short summary as a heading.                                        |
 | `weak`     | `readonly string[]` | The weak points.                                                       |
 
-### `ResourcesAccessor<T, K>`
+### `VectorType`
+
+A type definition of a structure that
+stores a description of a personality type.
+
+```ts
+interface VectorType {
+  readonly detail: string;
+  readonly name: string;
+  readonly strategy: readonly string[];
+}
+```
+
+| Property   | Type                | Description                                                            |
+| :--------- | :------------------ | :--------------------------------------------------------------------- |
+| `detail`   | `string`            | The detail.                                                            |
+| `name`     | `string`            | The resource name as a heading.                                        |
+| `strategy` | `readonly string[]` | The strategies for communicating with people of this personality type. |
+
+<!-- markdownlint-disable MD033 -->
+<details>
+<summary>Deprecated documents</summary>
+
+---
+
+## Deprecated type definitions (for TypeScript)
+
+### ~~`ResourcesAccessor<T, K, D>`~~
+
+> **DEPRECATED**: Use the [`DetailAccessor<T, K, D>`](#detailaccessort-k-d)
+> type definition instead of this type definition.
+> This will may no longer the next update.
 
 The type definition with a function to
 access a resource of the specific category.
@@ -342,29 +400,15 @@ interface ResourcesAccessor<
 | `K`  | `string`                    | The type for the key.                                      |
 | `D`  | `DetailsBaseType \| string` | The type of resource as a return value of category detail. |
 
-| Method                                              | Description                                                                               |
+| Method definition                                   | Description                                                                               |
 | :-------------------------------------------------- | :---------------------------------------------------------------------------------------- |
 | `getAsync(key: K): Promise<T \| undefined>`         | The function acquires the resource corresponding to the key asynchronously.               |
 | `getCategoryDetailAsync(): Promise<D \| undefined>` | The function acquires the resource corresponding to the specific category asynchronously. |
 
-### `VectorType`
+---
 
-A type definition of a structure that
-stores a description of a personality type.
-
-```ts
-interface VectorType {
-  readonly detail: string;
-  readonly name: string;
-  readonly strategy: readonly string[];
-}
-```
-
-| Property   | Type                | Description                                                            |
-| :--------- | :------------------ | :--------------------------------------------------------------------- |
-| `detail`   | `string`            | The detail.                                                            |
-| `name`     | `string`            | The resource name as a heading.                                        |
-| `strategy` | `readonly string[]` | The strategies for communicating with people of this personality type. |
+</details>
+<!-- markdownlint-enable MD033 -->
 
 ## See also
 

--- a/packages/dantalion-i18n/src/build/index.ts
+++ b/packages/dantalion-i18n/src/build/index.ts
@@ -57,5 +57,3 @@ export const getDetailMarkdownAsync = async (
         body: list(...types.genius),
       });
 };
-
-export default undefined;

--- a/packages/dantalion-i18n/src/build/index.ts
+++ b/packages/dantalion-i18n/src/build/index.ts
@@ -15,7 +15,8 @@ import { detailsAsync, personalityAsync } from './template';
  * to December 31, 2050.
  *
  * Ignore the _time_ information.
- * @returns The string that the personality information.
+ * @returns The string that the personality information
+ * as the Markdown format.
  *
  * If the date is over the range, it will be error message.
  */
@@ -35,9 +36,11 @@ export const getPersonalityMarkdownAsync = async (
 /**
  * Get the personality information.
  * @param genius The types of personality.
- * @returns The string that the personality information.
+ * @returns The string that the personality information
+ * as the Markdown format.
  *
- * If the omitted, it will be list of the available types.
+ * If you specified the `undefined` value as an argument or omitted it,
+ * it would be a list of the available types.
  */
 export const getDetailMarkdownAsync = async (
   genius?: Genius

--- a/packages/dantalion-i18n/src/build/template.ts
+++ b/packages/dantalion-i18n/src/build/template.ts
@@ -80,5 +80,3 @@ export const personalityAsync = async (
     await fromLifeBaseAsync(source.lifeBase)
   );
 };
-
-export default undefined;

--- a/packages/dantalion-i18n/src/getLocale.ts
+++ b/packages/dantalion-i18n/src/getLocale.ts
@@ -5,6 +5,7 @@ import semverGte from 'semver/functions/gte';
  *
  * If the environment is on NodeJS and does not have Full-ICU,
  * it may get the default results.
+ * @returns The locale string e.g. `en-US`.
  */
 const getLocaleFromIntlApi = () =>
   Intl?.DateTimeFormat?.()?.resolvedOptions?.()?.locale;
@@ -13,6 +14,7 @@ const getLocaleFromIntlApi = () =>
  * Get the locale information from the environment variables.
  *
  * If the environment variables did not found, it gets via Intl API.
+ * @returns The locale string e.g. `en-US`.
  */
 const getLocaleFromEnv = () => {
   const { env } = process;
@@ -43,6 +45,7 @@ const isBrowser = () =>
 /**
  * It provides the appropriate locale information acquisition function
  * according to the current environment.
+ * @returns The locale string e.g. `en-US`.
  */
 export default isBrowser() || isAvailableDefaultNodeICU()
   ? getLocaleFromIntlApi

--- a/packages/dantalion-i18n/src/index.ts
+++ b/packages/dantalion-i18n/src/index.ts
@@ -13,6 +13,7 @@ export {
   vector,
 } from './resources/accessors';
 export type { ResourcesAccessor } from './resources/createAccessor';
+export type { DetailAccessor } from './resources/createGenericAccessor';
 export { default as createTAsync } from './resources/createTAsync';
 export type {
   DesctiptionsType,

--- a/packages/dantalion-i18n/src/index.ts
+++ b/packages/dantalion-i18n/src/index.ts
@@ -13,6 +13,7 @@ export {
   vector,
 } from './resources/accessors';
 export type { ResourcesAccessor } from './resources/createAccessor';
+export { default as createTAsync } from './resources/createTAsync';
 export type {
   DesctiptionsType,
   DetailsBaseType,

--- a/packages/dantalion-i18n/src/resources/createAccessor.ts
+++ b/packages/dantalion-i18n/src/resources/createAccessor.ts
@@ -1,11 +1,13 @@
-import type { StringMap, TOptions } from 'i18next';
-import { fallbackLng } from './createTAsync';
+import type { StringMap } from 'i18next';
+import createGenericAccessor from './createGenericAccessor';
 import getResourcesAsync from './getTAsync';
 import type { DetailsBaseType } from './types';
 
 /**
  * The type definition with a function to access
  * a resource of the specific category.
+ * @deprecated Use the `DetailAccessor<T, K, D>` type definition
+ * instead of this type definition. This will may no longer the next update.
  * @template T The type of resource as a return value.
  * @template K The type for the key.
  * @template D The type of resource as a return value of category detail.
@@ -32,6 +34,8 @@ export interface ResourcesAccessor<
 
 /**
  * The function acquires the resource corresponding to the key asynchronously.
+ * @deprecated Use the `Accessor.tObj()` method instead of this function.
+ * This will may no longer the next update.
  * @template T The type of resource as a return value.
  * @param key The key.
  * @param placeholder The placeholder for i18next.
@@ -44,19 +48,14 @@ export interface ResourcesAccessor<
 export const getAsync = async <T extends object>(
   key: string,
   placeholder?: StringMap
-): Promise<T | undefined> => {
-  const t = await getResourcesAsync();
-  const opts = Object.freeze<TOptions>({ returnObjects: true, ...placeholder });
-  const result = t<string | T>(key, opts);
-  const fallback = t<string | T>(key, { ...opts, lng: fallbackLng });
-  return typeof result === 'string' || typeof fallback === 'string'
-    ? undefined
-    : { ...fallback, ...result };
-};
+): Promise<T | undefined> =>
+  createGenericAccessor(await getResourcesAsync()).tObj<T>(key, placeholder);
 
 /**
  * Create the accessor functions that acquire the resource corresponding
  * to the specified category asynchronously.
+ * @deprecated Use the `Accessor.tDetail<T, K, D>()` method
+ * instead of this function. This will may no longer the next update.
  * @template T The type of resource as a return value.
  * @template K The type for the key.
  * @template D The type of resource as a return value of category detail.

--- a/packages/dantalion-i18n/src/resources/createAccessor.ts
+++ b/packages/dantalion-i18n/src/resources/createAccessor.ts
@@ -1,5 +1,6 @@
 import type { StringMap, TOptions } from 'i18next';
-import getResourcesAsync, { fallbackLng } from './getTAsync';
+import { fallbackLng } from './createTAsync';
+import getResourcesAsync from './getTAsync';
 import type { DetailsBaseType } from './types';
 
 /**

--- a/packages/dantalion-i18n/src/resources/createGenericAccessor.ts
+++ b/packages/dantalion-i18n/src/resources/createGenericAccessor.ts
@@ -1,0 +1,78 @@
+import type { StringMap, TFunction, TFunctionResult } from 'i18next';
+import type { DetailsBaseType } from './types';
+
+/**
+ * The type definition with a function to access
+ * a resource of the specific category.
+ * @template T The type of resource as a return value.
+ * @template K The type for the resource key.
+ * @template D The type of resource as a return value of category detail.
+ */
+export interface DetailAccessor<
+  T extends TFunctionResult,
+  K extends string = string,
+  D extends DetailsBaseType | string = DetailsBaseType
+> {
+  /** The function acquires the resource corresponding to the key. */
+  readonly getByKey: (
+    /** The key. */
+    key: K
+  ) => T;
+  /**
+   * The function acquires the resource corresponding to the specific category.
+   */
+  readonly getCategoryDetail: () => D;
+}
+
+/** The type definition of the resources accessors */
+export interface Accessor {
+  /** Get the resource as a detailed object */
+  readonly tDetail: <
+    T extends TFunctionResult,
+    K extends string = string,
+    D extends DetailsBaseType | string = DetailsBaseType
+  >(
+    /** The key of category. */
+    category: string
+  ) => DetailAccessor<T, K, D>;
+
+  /** Get the resource as an object */
+  readonly tObj: <T extends TFunctionResult>(
+    key: string,
+    placeholder?: StringMap
+  ) => T;
+
+  /** Get the resource as a detailed object */
+  readonly tStringedDetail: <K extends string = string>(
+    /** The key of category. */
+    category: string
+  ) => DetailAccessor<string, K, string>;
+}
+
+/**
+ * Create an accessor that gets the resource as an object
+ * @param t An i18next instance.
+ */
+const createTObj =
+  (t: TFunction): Accessor['tObj'] =>
+  /**
+   * Get the resource as an object
+   * @param key The key.
+   * @param placeholder The placeholder for i18next.
+   */
+  (key: string, placeholder?: StringMap) =>
+    t(key, { returnObjects: true, ...placeholder });
+
+/**
+ * Create the i18n function.
+ * @param t An i18next instance.
+ */
+export default (t: TFunction): Accessor => {
+  const tObj = createTObj(t);
+  const getDetail = (f: Accessor['tObj']) => (category: string) => {
+    const get = <T extends TFunctionResult>(key?: string) =>
+      f<T>([category, key ?? 'detail'].join('.'));
+    return { getCategoryDetail: get, getByKey: get };
+  };
+  return { tDetail: getDetail(tObj), tObj, tStringedDetail: getDetail(t) };
+};

--- a/packages/dantalion-i18n/src/resources/createTAsync.ts
+++ b/packages/dantalion-i18n/src/resources/createTAsync.ts
@@ -1,0 +1,32 @@
+import i18next, { Resource, ResourceLanguage, TFunction } from 'i18next';
+import merge from 'lodash.merge';
+import getLocale from '../getLocale';
+import en from './en.json';
+import ja from './ja.json';
+
+/** The language that uses as a fallback. */
+export const fallbackLng = 'en';
+
+/**
+ * Create the resources object.
+ * @param addition The additional resources.
+ */
+const initResources = (addition?: ResourceLanguage): Resource =>
+  Object.entries(merge(addition, { en, ja })).reduce<Resource>(
+    (acc, [k, v]) => ({ ...acc, [k]: { translation: v } }),
+    {}
+  );
+
+/**
+ * Create and initialize the i18next instance asynchronously.
+ * @param lng The language to use
+ *
+ * If omitted, the language used is detected from the current environment.
+ * @param addition Specify the additional resources if you need
+ * @see useLocale()
+ */
+export default async (
+  lng = getLocale(),
+  addition?: ResourceLanguage
+): Promise<TFunction> =>
+  i18next.init({ fallbackLng, lng, resources: initResources(addition) });

--- a/packages/dantalion-i18n/src/resources/en.json
+++ b/packages/dantalion-i18n/src/resources/en.json
@@ -91,23 +91,23 @@
       ],
       "weak": [
         "They tend to restrict themselves to their sphere of activity and tend to stay in their shells.",
-        "They tend to be too honest in their home positions, such as social networking sites, and many of them become verbally abusive and overly familiar even among their friends."
+        "They tend to be too honest in their home positions, such as social networking sites, and many of them become verbally abusive and overly familiar even among their friends.",
+        "Once they let their guard down, they may needlessly trust the other person too much."
       ]
     },
     "125": {
       "detail": [
         "They have big, romantic dreams.",
-        "Also, like older adults, they have a long view of life and have the aptitude to be stoic in the short term.",
-        "They hate the intrusive attitude of looking from above."
+        "Also, like older adults, they have a long view of life and have the aptitude to be stoic in the short term."
       ],
       "name": "Dreaming Type",
       "summary": "No rival in dreams and self-discipline! Straight to the goal in the long run.",
       "strategy": [
+        "When proposing things to them, it is easier to trust if you talk about the risks first and clarify them.",
         "If you suggest things to them in a humble way, they tend to influence easily.",
         "They hate intrusive attitudes from above. They can get along well with those who are not so good at it and tend to stress you out without even knowing it."
       ],
       "weak": [
-        "When proposing things to them, it is easier to trust if you talk about the risks first and clarify them.",
         "They are skeptical and tend to be slow to take things on.",
         "Reflection is critical, but for them, it can lead to regret because of too much."
       ]
@@ -270,8 +270,7 @@
       ],
       "weak": [
         "They have a strong sense of camaraderie, so when someone they know gets into trouble, they tend to nose into problems with them.",
-        "Their judgment starts to weaken because they tend to gather too much information from their surroundings.",
-        "Once they let their guard down, they may needlessly trust the other person too much."
+        "Their judgment starts to weaken because they tend to gather too much information from their surroundings."
       ]
     }
   },

--- a/packages/dantalion-i18n/src/resources/getTAsync.ts
+++ b/packages/dantalion-i18n/src/resources/getTAsync.ts
@@ -1,37 +1,17 @@
-import i18next, { TFunction } from 'i18next';
-import getLocale from '../getLocale';
-import en from './en.json';
-import ja from './ja.json';
-
-/** The language that uses as a fallback. */
-export const fallbackLng = 'en';
-
-/**
- * Build JSON for resources.
- * @param translation resources data.
- */
-const wrap = (translation: Record<string, unknown>) => ({ translation });
-
-/**
- * Create the i18n function.
- * @param language The language.
- *
- * If omitted, the language used is detected from the current environment.
- */
-const createInstance = (language?: string) =>
-  i18next.init({
-    fallbackLng,
-    lng: language ?? getLocale(),
-    debug: false,
-    resources: { en: wrap(en), ja: wrap(ja) },
-  });
+import type { TFunction } from 'i18next';
+import createTAsync from './createTAsync';
 
 /** Cached i18n function. */
 let t: TFunction;
-/** Get the cached i18n function. */
+
+/**
+ * Get the cached i18n function.
+ * @deprecated Use the `createTAsync()` function instead of this function.
+ * This will may no longer the next update.
+ */
 export default async (): Promise<TFunction> => {
   if (!t) {
-    t = await createInstance();
+    t = await createTAsync();
   }
   return t;
 };


### PR DESCRIPTION
### BREAKING CHANGE

- i18n: `ResourcesAccessor<T, K, D>` type definition will be deprecated.
  - This will may no longer the next update after.

### Feature

- i18n: Added and migrated the function that creates the generical assessor (a882ea3)
- i18n: split and exposed the i18n initializer (2f43699)

### Refactor

- core, i18n: Removed the unnecessary exports (5679d7e)

### Docs

- i18n: Fixed some resource that notation was wrong (6629d23)
- i18n: Improved the README (61715d2, 307b068, c9f8f4d)
