### PR TITLE
Migrated the new API of i18n

### DIFF
--- a/packages/dantalion-i18n/README.md
+++ b/packages/dantalion-i18n/README.md
@@ -82,6 +82,43 @@ The instance provides a set of functions that retrieve human-readable resources 
 - Type: `ResourcesAccessor<DetailsType, Communication>`
 - The [`Communication`](../dantalion-core#communication) type is a string literal union type provided by the `@kurone-kito/dantalion-core` library.
 
+### `createAccessors(t: i18next.TFunction): Accessors`
+
+Create the concreted accessors collection from the i18next instance
+
+#### Arguments
+
+| Name | Type                                                          | Defaults     | Description                  |
+| :--- | :------------------------------------------------------------ | :----------- | :--------------------------- |
+| `t`  | [`i18next.TFunction`](https://www.i18next.com/overview/api#t) | _(Required)_ | Specify the i18next instance |
+
+#### Returns
+
+[`Accessors`](#accessors): The instance of the concreted accessors collection
+
+### `createAccessorsAsync(lng?: string, addition?: ResourceLanguage): Promise<Accessors & i18next.WithT>`
+
+Create the concreted accessors collection asynchronously
+
+It is a synonym function that combines
+[`createAccessors()`](#createaccessorst-i18nexttfunction-accessors) and
+[`createTAsync()`](#createtasynclng-string-addition-i18nextresourcelanguage--undefined-promisei18nexttfunction).
+
+#### Arguments
+
+| Name       | Type                       | Defaults    | Description                                  |
+| :--------- | :------------------------- | :---------- | :------------------------------------------- |
+| `lng`      | `string?`                  | (\*)        | The language to use                          |
+| `addition` | `i18next.ResourceLanguage` | `undefined` | Specify the additional resources if you need |
+
+(\*: If omitted, the language used is detected from the current environment.
+See: [useLocale()](#getlocale-string--undefined))
+
+#### Returns
+
+[`Promise<Accessors & i18next.WithT>`](#accessors):
+The instance of the concreted accessors collection
+
 ### `createTAsync(lng?: string, addition?: i18next.ResourceLanguage | undefined): Promise<i18next.TFunction>`
 
 Create and initialize the i18next instance asynchronously
@@ -98,7 +135,7 @@ See: [useLocale()](#getlocale-string--undefined))
 
 #### Returns
 
-`Promise<i18next.TFunction>`:
+[`Promise<i18next.TFunction>`](https://www.i18next.com/overview/api#t):
 The i18next instance which already initialized the resources.
 
 ### `getDescriptionAsync(type?: string): Promise<DesctiptionsType | undefined>`
@@ -214,6 +251,45 @@ The instance provides a set of functions that retrieve human-readable resources 
 
 The strings contained in the object are in Markdown format. In the
 case of an array of strings, the elements separate for each paragraph.
+
+### `Accessors`
+
+The type definition of the concreted accessors collection
+
+```ts
+interface Accessors {
+  readonly brain: DetailAccessor<DetailsType, Brain>;
+  readonly communication: DetailAccessor<DetailsType, Communication>;
+  readonly genius: DetailAccessor<
+    PersonalityType,
+    Genius,
+    PersonalityDetailType
+  >;
+  readonly lifeBase: DetailAccessor<string, LifeBase, string>;
+  readonly management: DetailAccessor<DetailsType, Management>;
+  readonly motivation: DetailAccessor<string, Motivation, string>;
+  readonly position: DetailAccessor<DetailsType, Position>;
+  readonly response: DetailAccessor<DetailsType, Response>;
+  readonly vector: DetailAccessor<VectorType, Vector>;
+  getDescription(type?: string): DesctiptionsType;
+}
+```
+
+| Property        | Type                                                             | Description                                                                                                                                 |
+| :-------------- | :--------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------ |
+| `brain`         | `DetailAccessor<DetailsType, Brain>`                             | The instance provides a set of functions that retrieve human-readable resources related to the thought method.                              |
+| `communication` | `DetailAccessor<DetailsType, Communication>`                     | The instance provides a set of functions that retrieve human-readable resources related to dialogue policy.                                 |
+| `genius`        | `DetailAccessor<PersonalityType, Genius, PersonalityDetailType>` | The instance provides a set of functions that retrieve human-readable resources related to natural personality.                             |
+| `lifeBase`      | `DetailAccessor<string, LifeBase, string>`                       | The instance provides a set of functions that retrieve human-readable resources related to the base of ego type.                            |
+| `management`    | `DetailAccessor<DetailsType, Management>`                        | The instance provides a set of functions that retrieve human-readable resources related to risk and return thinking in specific people.     |
+| `motivation`    | `DetailAccessor<string, Motivation, string>`                     | The instance provides a set of functions that retrieve human-readable resources related to to an environment that is easy to get motivated. |
+| `position`      | `DetailAccessor<DetailsType, Position>`                          | The instance provides a set of functions that retrieve human-readable resources related to a talented role.                                 |
+| `response`      | `DetailAccessor<DetailsType, Response>`                          | The instance provides a set of functions that retrieve human-readable resources related to on-site or behind.                               |
+| `vector`        | `DetailAccessor<VectorType, Vector>`                             | The instance provides a set of functions that retrieve human-readable resources related to the major classification of personality.         |
+
+| Method definition                                 | Description                                    |
+| :------------------------------------------------ | :--------------------------------------------- |
+| `getDescription(type?: string): DesctiptionsType` | Get the resources of the descriptions heading. |
 
 ### `DesctiptionsType`
 

--- a/packages/dantalion-i18n/README.md
+++ b/packages/dantalion-i18n/README.md
@@ -164,7 +164,7 @@ The string that the personality information as the Markdown format.
 If you specified the `undefined` value as an argument or omitted it,
 it would be a list of the available types.
 
-### `getLocale(): string | undefined`
+### `getLocale(forceEnv?: boolean): string | undefined`
 
 It provides the appropriate locale information acquisition function
 according to the current environment.
@@ -175,11 +175,13 @@ decision. If not, it determines by the environment variables.
 
 #### Arguments
 
-(None)
+| Name       | Type                   | Defaults  | Description                                                                                            |
+| :--------- | :--------------------- | :-------- | :----------------------------------------------------------------------------------------------------- |
+| `forceEnv` | `boolean \| undefined` | undefined | If the value is truthy, the function selects the getting forcibly that from the environment variables. |
 
 #### Returns
 
-`string | undefined`: The locale string e.g. `en-US`.
+`string | undefined`: The locale string e.g. `en-US` or `en_US.UTF-8`.
 If it is not recognized correctly, it may return an undefined value.
 
 ### `getPersonalityMarkdownAsync(birth: string | number | Date): Promise<string>`

--- a/packages/dantalion-i18n/README.md
+++ b/packages/dantalion-i18n/README.md
@@ -48,18 +48,20 @@ Since it's a long sentence, it omitted some parts.
 
 ```json
 {
-  "name": "悠然タイプ",
-  "summary": "バランス型能力と面倒見が良い、勇者的ポジション",
+  "name": "Easygoing type",
+  "summary": "Balanced, capable and caring, a heroic position.",
   "detail": [
-    "重役社員のような、万能感と親分肌のような空気感を持つ人が多いです。",
+    "Many people have an air of all-around competence and boss authority, like an executive employee.",
     :
     :
   ],
   "weak": [
-    "悠然タイプの人は、自分が悪くても謝罪するのを嫌がります。責任や謝罪心を持っていても、それを表明するのが極端に苦手です。"
+    "They don't like to apologize even when it is their fault. Even if they have apologetic, they are not very good at expressing it."
+    :
+    :
   ],
   "strategy": [
-    "悠然タイプの人は自力でなんでもできてしまうがため、自分でなんでも抱えてしまいます。何かを任せる際は『やらせすぎない』よう注意すると良いでしょう。"
+    "They can do everything on their own, so they tend to take care of everything on their own. When you entrust them with something, be careful not to let them do too much."
   ]
 }
 ```

--- a/packages/dantalion-i18n/README.md
+++ b/packages/dantalion-i18n/README.md
@@ -126,18 +126,18 @@ The i18next instance which already initialized the resources.
 
 ### `getDetailMarkdown(accessors: Accessors, genius?: Genius): string`
 
-Get the personality information asynchronously.
+Get the personality information.
 
 #### Arguments
 
-| Name        | Type                                              | Defaults          | Description                           |
-| :---------- | :------------------------------------------------ | :---------------- | :------------------------------------ |
-| `genius`    | [`Genius \| undefined`](../dantalion-core#genius) | `undefined`       | The types of personality.             |
-| `accessors` | [`Accessors`](#accessors)                         | _(Auto generate)_ | The accessors instance for resources. |
+| Name        | Type                                              | Defaults     | Description                           |
+| :---------- | :------------------------------------------------ | :----------- | :------------------------------------ |
+| `accessors` | [`Accessors`](#accessors)                         | _(Required)_ | The accessors instance for resources. |
+| `genius`    | [`Genius \| undefined`](../dantalion-core#genius) | `undefined`  | The types of personality.             |
 
 #### Returns
 
-`Promise<string>`:
+`string`:
 The string that the personality information as the Markdown format.
 
 If you specified the `undefined` value as an argument or omitted it,
@@ -163,20 +163,20 @@ decision. If not, it determines by the environment variables.
 `string | undefined`: The locale string e.g. `en-US` or `en_US.UTF-8`.
 If it is not recognized correctly, it may return an undefined value.
 
-### `getPersonalityMarkdownAsync(birth: string | number | Date, accessors?: Accessors): Promise<string>`
+### `getPersonalityMarkdown(accessors: Accessors, birth: string | number | Date): string`
 
-Get the personality information corresponding to the specified birthday asynchronously.
+Get the personality information corresponding to the specified birthday.
 
 #### Arguments
 
-| Name        | Type                       | Defaults          | Description                                                                                                     |
-| :---------- | :------------------------- | :---------------- | :-------------------------------------------------------------------------------------------------------------- |
-| `birth`     | `string \| number \| Date` | _(Required)_      | Specify a birthday within the range from February 1, 1873, to December 31, 2050. Ignore the _time_ information. |
-| `accessors` | [`Accessors`](#accessors)  | _(Auto generate)_ | The accessors instance for resources.                                                                           |
+| Name     | Type                       | Defaults     | Description                                                                                                     |
+| :------- | :------------------------- | :----------- | :-------------------------------------------------------------------------------------------------------------- |
+| `genius` | [`Accessors`](#accessors)  | _(Required)_ | The accessors instance for resources.                                                                           |
+| `birth`  | `string \| number \| Date` | _(Required)_ | Specify a birthday within the range from February 1, 1873, to December 31, 2050. Ignore the _time_ information. |
 
 #### Returns
 
-`Promise<string>`:
+`string`:
 The string that the personality information as the Markdown format.
 If the date is over the range, it will be error message.
 

--- a/packages/dantalion-i18n/README.md
+++ b/packages/dantalion-i18n/README.md
@@ -68,20 +68,6 @@ Since it's a long sentence, it omitted some parts.
 
 ## API
 
-### `brain`
-
-The instance provides a set of functions that retrieve human-readable resources related to the thought method.
-
-- Type: `ResourcesAccessor<DetailsType, Brain>`
-- The [`Brain`](../dantalion-core#brain) type is a string literal union type provided by the `@kurone-kito/dantalion-core` library.
-
-### `communication`
-
-The instance provides a set of functions that retrieve human-readable resources related to dialogue policy.
-
-- Type: `ResourcesAccessor<DetailsType, Communication>`
-- The [`Communication`](../dantalion-core#communication) type is a string literal union type provided by the `@kurone-kito/dantalion-core` library.
-
 ### `createAccessors(t: i18next.TFunction): Accessors`
 
 Create the concreted accessors collection from the i18next instance
@@ -138,23 +124,16 @@ See: [useLocale()](#getlocale-string--undefined))
 [`Promise<i18next.TFunction>`](https://www.i18next.com/overview/api#t):
 The i18next instance which already initialized the resources.
 
-### `getDescriptionAsync(type?: string): Promise<DesctiptionsType | undefined>`
+### `getDetailMarkdown(accessors: Accessors, genius?: Genius): string`
 
-Get the resources of the descriptions heading.
-
-- Arguments:
-  - `type?: string | undefined`: The genius type or birthday.
-- Returns: The resources of the descriptions heading. ([`DesctiptionsType`](#desctiptionstype))
-
-### `getDetailMarkdownAsync(genius?: Genius): Promise<string>`
-
-Get the personality information.
+Get the personality information asynchronously.
 
 #### Arguments
 
-| Name     | Type                  | Defaults    | Description               |
-| :------- | :-------------------- | :---------- | :------------------------ |
-| `genius` | `Genius \| undefined` | `undefined` | The types of personality. |
+| Name        | Type                                              | Defaults          | Description                           |
+| :---------- | :------------------------------------------------ | :---------------- | :------------------------------------ |
+| `genius`    | [`Genius \| undefined`](../dantalion-core#genius) | `undefined`       | The types of personality.             |
+| `accessors` | [`Accessors`](#accessors)                         | _(Auto generate)_ | The accessors instance for resources. |
 
 #### Returns
 
@@ -184,70 +163,22 @@ decision. If not, it determines by the environment variables.
 `string | undefined`: The locale string e.g. `en-US` or `en_US.UTF-8`.
 If it is not recognized correctly, it may return an undefined value.
 
-### `getPersonalityMarkdownAsync(birth: string | number | Date): Promise<string>`
+### `getPersonalityMarkdownAsync(birth: string | number | Date, accessors?: Accessors): Promise<string>`
 
-Get the personality information corresponding to the specified birthday.
+Get the personality information corresponding to the specified birthday asynchronously.
 
 #### Arguments
 
-| Name    | Type                       | Defaults     | Description                                                                                                     |
-| :------ | :------------------------- | :----------- | :-------------------------------------------------------------------------------------------------------------- |
-| `birth` | `string \| number \| Date` | _(Required)_ | Specify a birthday within the range from February 1, 1873, to December 31, 2050. Ignore the _time_ information. |
+| Name        | Type                       | Defaults          | Description                                                                                                     |
+| :---------- | :------------------------- | :---------------- | :-------------------------------------------------------------------------------------------------------------- |
+| `birth`     | `string \| number \| Date` | _(Required)_      | Specify a birthday within the range from February 1, 1873, to December 31, 2050. Ignore the _time_ information. |
+| `accessors` | [`Accessors`](#accessors)  | _(Auto generate)_ | The accessors instance for resources.                                                                           |
 
 #### Returns
 
 `Promise<string>`:
 The string that the personality information as the Markdown format.
 If the date is over the range, it will be error message.
-
-### `genius`
-
-The instance provides a set of functions that retrieve human-readable resources related to natural personality.
-
-- Type: `ResourcesAccessor<PersonalityType, Genius, PersonalityDetailType>`
-- The [`Genius`](../dantalion-core#genius) type is a string literal union type provided by the `@kurone-kito/dantalion-core` library.
-
-### `lifeBase`
-
-The instance provides a set of functions that retrieve human-readable resources related to the base of ego type.
-
-- Type: `ResourcesAccessor<string, LifeBase, string>`
-- The [`LifeBase`](../dantalion-core#lifebase) type is a string literal union type provided by the `@kurone-kito/dantalion-core` library.
-
-### `management`
-
-The instance provides a set of functions that retrieve human-readable resources related to risk and return thinking in specific people.
-
-- Type: `ResourcesAccessor<DetailsType, Management>`
-- The [`Management`](../dantalion-core#management) type is a string literal union type provided by the `@kurone-kito/dantalion-core` library.
-
-### `motivation`
-
-The instance provides a set of functions that retrieve human-readable resources related to an environment that is easy to get motivated.
-
-- Type: `ResourcesAccessor<string, Motivation, string>`
-- The [`Motivation`](../dantalion-core#motivation) type is a string literal union type provided by the `@kurone-kito/dantalion-core` library.
-
-### `position`
-
-The instance provides a set of functions that retrieve human-readable resources related to a talented role.
-
-- Type: `ResourcesAccessor<DetailsType, Position>`
-- The [`Position`](../dantalion-core#position) type is a string literal union type provided by the `@kurone-kito/dantalion-core` library.
-
-### `response`
-
-The instance provides a set of functions that retrieve human-readable resources related to on-site or behind.
-
-- Type: `ResourcesAccessor<DetailsType, Response>`
-- The [`Response`](../dantalion-core#response) type is a string literal union type provided by the `@kurone-kito/dantalion-core` library.
-
-### `vector`
-
-The instance provides a set of functions that retrieve human-readable resources related to the major classification of personality.
-
-- Type: `ResourcesAccessor<VectorType, Vector>`
-- The [`Vector`](../dantalion-core#vector) type is a string literal union type provided by the `@kurone-kito/dantalion-core` library.
 
 ## Type definitions (for TypeScript)
 
@@ -451,6 +382,152 @@ interface VectorType {
 <summary>Deprecated documents</summary>
 
 ---
+
+### ~~`brain`~~
+
+> **DEPRECATED**: Use the [`Accessors.brain`](#accessors) instance property
+> instead of this constant. This will may no longer the next update.
+
+The instance provides a set of functions that retrieve human-readable resources related to the thought method.
+
+- Type: `ResourcesAccessor<DetailsType, Brain>`
+- The [`Brain`](../dantalion-core#brain) type is a string literal union type provided by the `@kurone-kito/dantalion-core` library.
+
+### ~~`communication`~~
+
+> **DEPRECATED**: Use the [`Accessors.communication`](#accessors) instance
+> property instead of this constant. This will may no longer the next update.
+
+The instance provides a set of functions that retrieve human-readable resources related to dialogue policy.
+
+- Type: `ResourcesAccessor<DetailsType, Communication>`
+- The [`Communication`](../dantalion-core#communication) type is a string literal union type provided by the `@kurone-kito/dantalion-core` library.
+
+### ~~`getDescriptionAsync(type?: string): Promise<DesctiptionsType | undefined>`~~
+
+> **DEPRECATED**: Use the [`Accessors.getDescription()`](#accessors)
+> instance method instead of this function.
+> This will may no longer the next update.
+
+Get the resources of the descriptions heading.
+
+- Arguments:
+  - `type?: string | undefined`: The genius type or birthday.
+- Returns: The resources of the descriptions heading. ([`DesctiptionsType`](#desctiptionstype))
+
+### ~~`getDetailMarkdownAsync(genius?: Genius, accessors?: Accessors): Promise<string>`~~
+
+> **DEPRECATED**: Use the
+> [`getDetailMarkdown()`](#getdetailmarkdownaccessors-accessors-genius-genius-string)
+> function instead of this function. This will may no longer the next update.
+
+Get the personality information asynchronously.
+
+#### Arguments
+
+| Name        | Type                                              | Defaults          | Description                           |
+| :---------- | :------------------------------------------------ | :---------------- | :------------------------------------ |
+| `genius`    | [`Genius \| undefined`](../dantalion-core#genius) | `undefined`       | The types of personality.             |
+| `accessors` | [`Accessors`](#accessors)                         | _(Auto generate)_ | The accessors instance for resources. |
+
+#### Returns
+
+`Promise<string>`:
+The string that the personality information as the Markdown format.
+
+If you specified the `undefined` value as an argument or omitted it,
+it would be a list of the available types.
+
+### ~~`getPersonalityMarkdownAsync(birth: string | number | Date, accessors?: Accessors): Promise<string>`~~
+
+> **DEPRECATED**: Use the
+> [`getPersonalityMarkdown()`](#getpersonalitymarkdownaccessors-accessors-birth-string--number--date-string)
+> function instead of this function. This will may no longer the next update.
+
+Get the personality information corresponding to the specified birthday asynchronously.
+
+#### Arguments
+
+| Name        | Type                       | Defaults          | Description                                                                                                     |
+| :---------- | :------------------------- | :---------------- | :-------------------------------------------------------------------------------------------------------------- |
+| `birth`     | `string \| number \| Date` | _(Required)_      | Specify a birthday within the range from February 1, 1873, to December 31, 2050. Ignore the _time_ information. |
+| `accessors` | [`Accessors`](#accessors)  | _(Auto generate)_ | The accessors instance for resources.                                                                           |
+
+#### Returns
+
+`Promise<string>`:
+The string that the personality information as the Markdown format.
+If the date is over the range, it will be error message.
+
+### ~~`genius`~~
+
+> **DEPRECATED**: Use the [`Accessors.genius`](#accessors) instance
+> property instead of this constant. This will may no longer the next update.
+
+The instance provides a set of functions that retrieve human-readable resources related to natural personality.
+
+- Type: `ResourcesAccessor<PersonalityType, Genius, PersonalityDetailType>`
+- The [`Genius`](../dantalion-core#genius) type is a string literal union type provided by the `@kurone-kito/dantalion-core` library.
+
+### ~~`lifeBase`~~
+
+> **DEPRECATED**: Use the [`Accessors.lifeBase`](#accessors) instance
+> property instead of this constant. This will may no longer the next update.
+
+The instance provides a set of functions that retrieve human-readable resources related to the base of ego type.
+
+- Type: `ResourcesAccessor<string, LifeBase, string>`
+- The [`LifeBase`](../dantalion-core#lifebase) type is a string literal union type provided by the `@kurone-kito/dantalion-core` library.
+
+### ~~`management`~~
+
+> **DEPRECATED**: Use the [`Accessors.management`](#accessors) instance
+> property instead of this constant. This will may no longer the next update.
+
+The instance provides a set of functions that retrieve human-readable resources related to risk and return thinking in specific people.
+
+- Type: `ResourcesAccessor<DetailsType, Management>`
+- The [`Management`](../dantalion-core#management) type is a string literal union type provided by the `@kurone-kito/dantalion-core` library.
+
+### ~~`motivation`~~
+
+> **DEPRECATED**: Use the [`Accessors.motivation`](#accessors) instance
+> property instead of this constant. This will may no longer the next update.
+
+The instance provides a set of functions that retrieve human-readable resources related to an environment that is easy to get motivated.
+
+- Type: `ResourcesAccessor<string, Motivation, string>`
+- The [`Motivation`](../dantalion-core#motivation) type is a string literal union type provided by the `@kurone-kito/dantalion-core` library.
+
+### ~~`position`~~
+
+> **DEPRECATED**: Use the [`Accessors.position`](#accessors) instance
+> property instead of this constant. This will may no longer the next update.
+
+The instance provides a set of functions that retrieve human-readable resources related to a talented role.
+
+- Type: `ResourcesAccessor<DetailsType, Position>`
+- The [`Position`](../dantalion-core#position) type is a string literal union type provided by the `@kurone-kito/dantalion-core` library.
+
+### ~~`response`~~
+
+> **DEPRECATED**: Use the [`Accessors.response`](#accessors) instance
+> property instead of this constant. This will may no longer the next update.
+
+The instance provides a set of functions that retrieve human-readable resources related to on-site or behind.
+
+- Type: `ResourcesAccessor<DetailsType, Response>`
+- The [`Response`](../dantalion-core#response) type is a string literal union type provided by the `@kurone-kito/dantalion-core` library.
+
+### ~~`vector`~~
+
+> **DEPRECATED**: Use the [`Accessors.vector`](#accessors) instance
+> property instead of this constant. This will may no longer the next update.
+
+The instance provides a set of functions that retrieve human-readable resources related to the major classification of personality.
+
+- Type: `ResourcesAccessor<VectorType, Vector>`
+- The [`Vector`](../dantalion-core#vector) type is a string literal union type provided by the `@kurone-kito/dantalion-core` library.
 
 ## Deprecated type definitions (for TypeScript)
 

--- a/packages/dantalion-i18n/src/build/details.ts
+++ b/packages/dantalion-i18n/src/build/details.ts
@@ -6,11 +6,11 @@ import { line, list } from './list';
  * The options for the `detailsBase` and `detailsMore` function.
  * @template S The type of source object.
  */
-export interface Options<S extends DetailsBaseType> {
+export interface Options<S extends DetailsBaseType = DetailsBaseType> {
   /** The additional strings. */
-  readonly additional?: string;
+  readonly addition?: string;
   /** The source. */
-  readonly source?: S;
+  readonly src: S;
   /**
    * The heading level.
    *
@@ -27,17 +27,11 @@ export interface Options<S extends DetailsBaseType> {
  * If omitted, its default value is `2`.
  */
 export const detailsBase = ({
-  additional = '',
+  addition = '',
   level = 2,
-  source,
-}: Options<DetailsBaseType>): string =>
-  source
-    ? article({
-        body: `${source.detail} ${additional}`,
-        head: source.name,
-        level,
-      })
-    : '';
+  src,
+}: Options): string =>
+  article({ body: `${src.detail} ${addition}`, head: src.name, level });
 
 /**
  * Create the Markdown from the DetailsType object.
@@ -45,9 +39,7 @@ export const detailsBase = ({
  */
 export const detailsMore = ({
   level = 3,
-  source,
-  ...options
+  src,
+  ...rest
 }: Options<DetailsType>): string =>
-  source
-    ? line(detailsBase({ level, source, ...options }), list(...source.more))
-    : '';
+  line(detailsBase({ level, src, ...rest }), list(...src.more));

--- a/packages/dantalion-i18n/src/build/index.ts
+++ b/packages/dantalion-i18n/src/build/index.ts
@@ -14,21 +14,19 @@ import { createDetailsTemplate, createPersonalityTemplate } from './template';
 type ParsableDate = ConstructorParameters<typeof Date>[0];
 
 /**
- * Get the personality information asynchronously.
- * @param genius The types of personality.
+ * Get the personality information.
  * @param accessors The accessors instance for resources.
+ * @param genius The types of personality.
  * @returns The string that the personality information
  * as the Markdown format.
  *
  * If you specified the `undefined` value as an argument or omitted it,
  * it would be a list of the available types.
  */
-export const getDetailMarkdownAsync = async (
-  genius?: Genius,
-  accessors?: Accessors
-): Promise<string> => {
-  // eslint-disable-next-line no-param-reassign
-  accessors ??= await createAccessorsAsync();
+export const getDetailMarkdown = (
+  accessors: Accessors,
+  genius?: Genius
+): string => {
   const result = genius && getDetail(genius);
   const desc = accessors.getDescription(genius);
   return genius && result
@@ -43,8 +41,60 @@ export const getDetailMarkdownAsync = async (
 };
 
 /**
+ * Get the personality information asynchronously.
+ *
+ * It is a synonym function that combines
+ * `getDetailMarkdown()` and `createAccessorsAsync()`.
+ * @deprecated Use the `getDetailMarkdown()` function instead of
+ * this function. This will may no longer the next update.
+ * @param genius The types of personality.
+ * @param accessors The accessors instance for resources.
+ * @returns The string that the personality information
+ * as the Markdown format.
+ *
+ * If you specified the `undefined` value as an argument or omitted it,
+ * it would be a list of the available types.
+ */
+export const getDetailMarkdownAsync = async (
+  genius?: Genius,
+  accessors?: Accessors
+): Promise<string> =>
+  getDetailMarkdown(accessors ?? (await createAccessorsAsync()), genius);
+
+/**
+ * Get the personality information corresponding to the specified birthday.
+ * @param accessors The accessors instance for resources.
+ * @param birth Specify a birthday within the range from February 1, 1873,
+ * to December 31, 2050.
+ *
+ * Ignore the _time_ information.
+ * @returns The string that the personality information
+ * as the Markdown format.
+ *
+ * If the date is over the range, it will be error message.
+ */
+export const getPersonalityMarkdown = (
+  accessors: Accessors,
+  birth: ParsableDate
+): string => {
+  const result = getPersonality(birth);
+  const desc = accessors.getDescription(new Date(birth).toDateString());
+  return result
+    ? article({
+        body: createPersonalityTemplate(result, accessors),
+        head: `Dantalion: ${desc.personality}`,
+      })
+    : article({ head: `Dantalion: ${desc.invalid}` });
+};
+
+/**
  * Get the personality information corresponding
  * to the specified birthday asynchronously.
+ *
+ * It is a synonym function that combines
+ * `getPersonalityMarkdown()` and `createAccessorsAsync()`.
+ * @deprecated Use the `getPersonalityMarkdown()` function instead of
+ * this function. This will may no longer the next update.
  * @param birth Specify a birthday within the range from February 1, 1873,
  * to December 31, 2050.
  *
@@ -58,15 +108,5 @@ export const getDetailMarkdownAsync = async (
 export const getPersonalityMarkdownAsync = async (
   birth: ParsableDate,
   accessors?: Accessors
-): Promise<string> => {
-  // eslint-disable-next-line no-param-reassign
-  accessors ??= await createAccessorsAsync();
-  const result = getPersonality(birth);
-  const desc = accessors.getDescription(new Date(birth).toDateString());
-  return result
-    ? article({
-        body: createPersonalityTemplate(result, accessors),
-        head: `Dantalion: ${desc.personality}`,
-      })
-    : article({ head: `Dantalion: ${desc.invalid}` });
-};
+): Promise<string> =>
+  getPersonalityMarkdown(accessors ?? (await createAccessorsAsync()), birth);

--- a/packages/dantalion-i18n/src/build/specialized.ts
+++ b/packages/dantalion-i18n/src/build/specialized.ts
@@ -1,53 +1,38 @@
 import type { LifeBase, Motivation } from '@kurone-kito/dantalion-core';
-import {
-  getDescriptionAsync,
-  lifeBase,
-  motivation,
-} from '../resources/accessors';
+import type { DetailAccessor } from '../resources/createGenericAccessor';
 import type { VectorType } from '../resources/types';
 import article from './article';
 import { line, list } from './list';
 
 /**
  * Create the Markdown from the LifeBase resources.
+ * @param resource The resource of tne LifeBase.
  * @param source The source.
  */
-export const fromLifeBaseAsync = async (source?: LifeBase): Promise<string> =>
-  source
-    ? article({
-        body: await lifeBase.getAsync(source),
-        head: await lifeBase.getCategoryDetailAsync(),
-        level: 2,
-      })
-    : '';
+export const fromLifeBase = (
+  { getByKey, getCategoryDetail }: DetailAccessor<string, LifeBase, string>,
+  source: LifeBase
+): string =>
+  article({ body: getByKey(source), head: getCategoryDetail(), level: 2 });
 
 /**
  * Create the Markdown from the Motivation resources.
+ * @param resource The resource of tne motivation.
  * @param source The source.
  */
-export const fromMotivationAsync = async (
-  source?: Motivation
-): Promise<string> =>
-  source
-    ? article({
-        body: await motivation.getAsync(source),
-        head: await motivation.getCategoryDetailAsync(),
-        level: 2,
-      })
-    : '';
+export const fromMotivation = (
+  { getByKey, getCategoryDetail }: DetailAccessor<string, Motivation, string>,
+  source: Motivation
+): string =>
+  article({ body: getByKey(source), head: getCategoryDetail(), level: 2 });
 
 /**
  * Create the Markdown from the vector resources.
+ * @param description The resource of tne description.
  * @param source The source.
  */
-export const fromVectorAsync = async (source?: VectorType): Promise<string> =>
-  source
-    ? line(
-        article({ head: source.name, body: list(...source.detail), level: 3 }),
-        article({
-          head: (await getDescriptionAsync())?.strategy,
-          body: list(...source.strategy),
-          level: 4,
-        })
-      )
-    : '';
+export const fromVector = (description: string, source: VectorType): string =>
+  line(
+    article({ head: source.name, body: list(...source.detail), level: 3 }),
+    article({ head: description, body: list(...source.strategy), level: 4 })
+  );

--- a/packages/dantalion-i18n/src/getLocale.spec.ts
+++ b/packages/dantalion-i18n/src/getLocale.spec.ts
@@ -1,0 +1,14 @@
+import getLocale from './getLocale';
+
+describe('`getLocale()` function', () => {
+  describe.each([false, undefined])('getLocale(%p)', (forceEnv) => {
+    it('Get the string', () =>
+      expect(getLocale(forceEnv)).toEqual(expect.any(String)));
+    it('Get the same value', () =>
+      expect(getLocale(forceEnv)).toBe(getLocale()));
+  });
+  describe('getLocale(true)', () => {
+    it('Get the string', () =>
+      expect(getLocale(true)).toEqual(expect.any(String)));
+  });
+});

--- a/packages/dantalion-i18n/src/getLocale.ts
+++ b/packages/dantalion-i18n/src/getLocale.ts
@@ -8,23 +8,15 @@ import semverGte from 'semver/functions/gte';
  * @returns The locale string e.g. `en-US`.
  */
 const getLocaleFromIntlApi = () =>
-  Intl?.DateTimeFormat?.()?.resolvedOptions?.()?.locale;
+  Intl.DateTimeFormat().resolvedOptions().locale;
 
 /**
  * Get the locale information from the environment variables.
- *
- * If the environment variables did not found, it gets via Intl API.
- * @returns The locale string e.g. `en-US`.
+ * @returns The locale string e.g. `en_US.UTF-8`.
  */
 const getLocaleFromEnv = () => {
   const { env } = process;
-  return (
-    env.LC_ALL ||
-    env.LC_MESSAGES ||
-    env.LANG ||
-    env.LANGUAGE ||
-    getLocaleFromIntlApi()
-  );
+  return env.LC_ALL || env.LC_MESSAGES || env.LANG || env.LANGUAGE;
 };
 
 /**
@@ -43,10 +35,13 @@ const isBrowser = () =>
   )();
 
 /**
- * It provides the appropriate locale information acquisition function
- * according to the current environment.
- * @returns The locale string e.g. `en-US`.
+ * It provides the appropriate locale information acquisition
+ * function according to the current environment.
+ * @param forceEnv If the value is truthy, the function selects
+ * the getting forcibly that from the environment variables.
+ * @returns The locale string e.g. `en-US` or `en_US.UTF-8`.
  */
-export default isBrowser() || isAvailableDefaultNodeICU()
-  ? getLocaleFromIntlApi
-  : getLocaleFromEnv;
+export default (forceEnv?: boolean): string =>
+  ((forceEnv || !(isBrowser() || isAvailableDefaultNodeICU())) &&
+    getLocaleFromEnv()) ||
+  getLocaleFromIntlApi();

--- a/packages/dantalion-i18n/src/index.spec.ts
+++ b/packages/dantalion-i18n/src/index.spec.ts
@@ -14,7 +14,6 @@ import {
   communication,
   genius,
   getDescriptionAsync,
-  getLocale,
   lifeBase,
   management,
   motivation,
@@ -50,10 +49,6 @@ describe('integration testing', () => {
           weak: expect.any(String),
         })
     );
-  });
-  describe('`getLocale()` function', () => {
-    it('Get the string', () => expect(getLocale()).toEqual(expect.any(String)));
-    it('Get the same value', () => expect(getLocale()).toBe(getLocale()));
   });
   describe('The `brain` instance', () => {
     it('getCategoryDetailAsync() method', async () =>

--- a/packages/dantalion-i18n/src/index.ts
+++ b/packages/dantalion-i18n/src/index.ts
@@ -1,5 +1,10 @@
 export { default as getLocale } from './getLocale';
-export { getPersonalityMarkdownAsync, getDetailMarkdownAsync } from './build';
+export {
+  getDetailMarkdown,
+  getDetailMarkdownAsync,
+  getPersonalityMarkdown,
+  getPersonalityMarkdownAsync,
+} from './build';
 export {
   brain,
   communication,

--- a/packages/dantalion-i18n/src/index.ts
+++ b/packages/dantalion-i18n/src/index.ts
@@ -12,6 +12,11 @@ export {
   response,
   vector,
 } from './resources/accessors';
+export {
+  Accessors,
+  createAccessors,
+  default as createAccessorsAsync,
+} from './resources/createAccessorsAsync';
 export type { ResourcesAccessor } from './resources/createAccessor';
 export type { DetailAccessor } from './resources/createGenericAccessor';
 export { default as createTAsync } from './resources/createTAsync';

--- a/packages/dantalion-i18n/src/resources/accessors.ts
+++ b/packages/dantalion-i18n/src/resources/accessors.ts
@@ -22,12 +22,16 @@ import getResourcesAsync from './getTAsync';
 /**
  * The instance provides a set of functions that retrieve
  * human-readable resources related to the thought method.
+ * @deprecated Use the `Accessors.brain` instance property instead of
+ * this constant. This will may no longer the next update.
  */
 export const brain = createAccessor<DetailsType, Brain>('brain');
 
 /**
  * The instance provides a set of functions that retrieve
  * human-readable resources related to dialogue policy.
+ * @deprecated Use the `Accessors.communication` instance property
+ * instead of this constant. This will may no longer the next update.
  */
 export const communication =
   createAccessor<DetailsType, Communication>('communication');
@@ -35,6 +39,8 @@ export const communication =
 /**
  * The instance provides a set of functions that retrieve
  * human-readable resources related to natural personality.
+ * @deprecated Use the `Accessors.genius` instance property instead of
+ * this constant. This will may no longer the next update.
  */
 export const genius =
   createAccessor<PersonalityType, Genius, PersonalityDetailType>('genius');
@@ -42,6 +48,8 @@ export const genius =
 /**
  * Get the resources of the descriptions heading.
  * @param type The genius type or birthday.
+ * @deprecated Use the `Accessors.getDescription()` instance method
+ * instead of this function. This will may no longer the next update.
  */
 export const getDescriptionAsync = (
   type?: string
@@ -51,6 +59,8 @@ export const getDescriptionAsync = (
 /**
  * The instance provides a set of functions that retrieve
  * human-readable resources related to the base of ego type.
+ * @deprecated Use the `Accessors.lifeBase` instance property instead of
+ * this constant. This will may no longer the next update.
  */
 export const lifeBase: ResourcesAccessor<string, LifeBase, string> = {
   getAsync: async (key) => (await getResourcesAsync())(`lifeBase.${key}`),
@@ -61,12 +71,16 @@ export const lifeBase: ResourcesAccessor<string, LifeBase, string> = {
 /**
  * The instance provides a set of functions that retrieve human-readable
  * resources related to risk and return thinking in specific people.
+ * @deprecated Use the `Accessors.management` instance property instead of
+ * this constant. This will may no longer the next update.
  */
 export const management = createAccessor<DetailsType, Management>('management');
 
 /**
  * The instance provides a set of functions that retrieve human-readable
  * resources related to an environment that is easy to get motivated.
+ * @deprecated Use the `Accessors.motivation` instance property instead of
+ * this constant. This will may no longer the next update.
  */
 export const motivation: ResourcesAccessor<string, Motivation, string> = {
   getAsync: async (key) => (await getResourcesAsync())(`motivation.${key}`),
@@ -77,17 +91,23 @@ export const motivation: ResourcesAccessor<string, Motivation, string> = {
 /**
  * The instance provides a set of functions that retrieve
  * human-readable resources related to a talented role.
+ * @deprecated Use the `Accessors.position` instance property instead of
+ * this constant. This will may no longer the next update.
  */
 export const position = createAccessor<DetailsType, Position>('position');
 
 /**
  * The instance provides a set of functions that retrieve
  * human-readable resources related to on-site or behind.
+ * @deprecated Use the `Accessors.response` instance property instead of
+ * this constant. This will may no longer the next update.
  */
 export const response = createAccessor<DetailsType, Response>('response');
 
 /**
  * The instance provides a set of functions that retrieve human-readable
  * resources related to the major classification of personality.
+ * @deprecated Use the `Accessors.vector` instance property instead of
+ * this constant. This will may no longer the next update.
  */
 export const vector = createAccessor<VectorType, Vector>('vector');

--- a/packages/dantalion-i18n/src/resources/createAccessorsAsync.spec.ts
+++ b/packages/dantalion-i18n/src/resources/createAccessorsAsync.spec.ts
@@ -1,0 +1,261 @@
+import type {
+  Brain,
+  Communication,
+  Genius,
+  LifeBase,
+  Management,
+  Motivation,
+  Position,
+  Response,
+  Vector,
+} from '@kurone-kito/dantalion-core';
+import createAccessorsAsync, { createAccessors } from './createAccessorsAsync';
+import createTAsync from './createTAsync';
+
+describe('`createAccessors()` function', () => {
+  it('(t) => Get the Accessors object', async () =>
+    expect(createAccessors(await createTAsync())).toEqual({
+      brain: expect.any(Object),
+      communication: expect.any(Object),
+      genius: expect.any(Object),
+      getDescription: expect.any(Function),
+      lifeBase: expect.any(Object),
+      management: expect.any(Object),
+      motivation: expect.any(Object),
+      position: expect.any(Object),
+      response: expect.any(Object),
+      vector: expect.any(Object),
+    }));
+});
+describe('`createAccessorsAsync()` function', () => {
+  it('Get the (Accessors & i18next.WithT) object', async () =>
+    expect(await createAccessorsAsync()).toEqual({
+      brain: expect.any(Object),
+      communication: expect.any(Object),
+      genius: expect.any(Object),
+      getDescription: expect.any(Function),
+      lifeBase: expect.any(Object),
+      management: expect.any(Object),
+      motivation: expect.any(Object),
+      position: expect.any(Object),
+      response: expect.any(Object),
+      t: expect.any(Function),
+      vector: expect.any(Object),
+    }));
+});
+describe.each([
+  ['createAccessors', async () => createAccessors(await createTAsync())],
+  ['createAccessorsAsync', createAccessorsAsync],
+])('`%s()` function', (__, func) => {
+  describe('`Accessors.brain.getByKey()` method', () => {
+    it.each<Brain>(['left', 'right'])(
+      '("%s") => Get the specified object',
+      async (key) =>
+        expect((await func()).brain.getByKey(key)).toEqual({
+          detail: expect.any(String),
+          more: expect.any(Array),
+          name: expect.any(String),
+        })
+    );
+  });
+  describe('`Accessors.brain.getCategoryDetail()` method', () => {
+    it('Get the specified object', async () =>
+      expect((await func()).brain.getCategoryDetail()).toEqual({
+        detail: expect.any(String),
+        name: expect.any(String),
+      }));
+  });
+  describe('`Accessors.communication.getByKey()` method', () => {
+    it.each<Communication>(['fix', 'flex'])(
+      '("%s") => Get the specified object',
+      async (key) =>
+        expect((await func()).communication.getByKey(key)).toEqual({
+          detail: expect.any(String),
+          more: expect.any(Array),
+          name: expect.any(String),
+        })
+    );
+  });
+  describe('`Accessors.communication.getCategoryDetail()` method', () => {
+    it('Get the specified object', async () =>
+      expect((await func()).communication.getCategoryDetail()).toEqual({
+        detail: expect.any(String),
+        name: expect.any(String),
+      }));
+  });
+  describe('`Accessors.genius.getByKey()` method', () => {
+    it.each<Genius>([
+      '000',
+      '001',
+      '012',
+      '024',
+      '025',
+      '100',
+      '108',
+      '125',
+      '555',
+      '789',
+      '888',
+      '919',
+    ])('("%s") => Get the specified object', async (key) =>
+      expect((await func()).genius.getByKey(key)).toEqual({
+        detail: expect.any(Array),
+        name: expect.any(String),
+        strategy: expect.any(Array),
+        summary: expect.any(String),
+        weak: expect.any(Array),
+      })
+    );
+  });
+  describe('`Accessors.genius.getCategoryDetail()` method', () => {
+    it('Get the specified object', async () =>
+      expect((await func()).genius.getCategoryDetail()).toEqual({
+        detail: expect.any(String),
+        inner: expect.any(String),
+        name: expect.any(String),
+        outer: expect.any(String),
+        workStyle: expect.any(String),
+      }));
+  });
+  describe('`Accessors.getDescription()` method', () => {
+    it('Get the specified object', async () =>
+      expect((await func()).getDescription()).toEqual({
+        detail: expect.any(String),
+        details: expect.any(String),
+        genius1: expect.any(String),
+        genius2: expect.any(String),
+        invalid: expect.any(String),
+        personality: expect.any(String),
+        strategy: expect.any(String),
+        weak: expect.any(String),
+      }));
+    it.each(['foo', 'bar'])(
+      '("%s") => includes the same string',
+      async (placeholder) =>
+        expect((await func()).getDescription(placeholder)).toEqual({
+          detail: expect.stringContaining(placeholder),
+          details: expect.any(String),
+          genius1: expect.any(String),
+          genius2: expect.any(String),
+          invalid: expect.stringContaining(placeholder),
+          personality: expect.stringContaining(placeholder),
+          strategy: expect.any(String),
+          weak: expect.any(String),
+        })
+    );
+  });
+  describe('`Accessors.lifeBase.getByKey()` method', () => {
+    it.each<LifeBase>([
+      'application',
+      'association',
+      'development',
+      'expression',
+      'finance',
+      'investment',
+      'organization',
+      'quest',
+      'selfMind',
+      'selfReliance',
+    ])('("%s") => Get the specified object', async (key) =>
+      expect((await func()).lifeBase.getByKey(key)).toEqual(expect.any(String))
+    );
+  });
+  describe('`Accessors.lifeBase.getCategoryDetail()` method', () => {
+    it('Get the specified object', async () =>
+      expect((await func()).lifeBase.getCategoryDetail()).toEqual(
+        expect.any(String)
+      ));
+  });
+  describe('`Accessors.management.getByKey()` method', () => {
+    it.each<Management>(['care', 'hope'])(
+      '("%s") => Get the specified object',
+      async (key) =>
+        expect((await func()).management.getByKey(key)).toEqual({
+          detail: expect.any(String),
+          more: expect.any(Array),
+          name: expect.any(String),
+        })
+    );
+  });
+  describe('`Accessors.management.getCategoryDetail()` method', () => {
+    it('Get the specified object', async () =>
+      expect((await func()).management.getCategoryDetail()).toEqual({
+        detail: expect.any(String),
+        name: expect.any(String),
+      }));
+  });
+  describe('`Accessors.motivation.getByKey()` method', () => {
+    it.each<Motivation>([
+      'competition',
+      'ownMind',
+      'power',
+      'safety',
+      'skillUp',
+      'status',
+    ])('("%s") => Get the specified object', async (key) =>
+      expect((await func()).motivation.getByKey(key)).toEqual(
+        expect.any(String)
+      )
+    );
+  });
+  describe('`Accessors.motivation.getCategoryDetail()` method', () => {
+    it('Get the specified object', async () =>
+      expect((await func()).motivation.getCategoryDetail()).toEqual(
+        expect.any(String)
+      ));
+  });
+  describe('`Accessors.position.getByKey()` method', () => {
+    it.each<Position>(['adjust', 'brain', 'direct', 'quick'])(
+      '("%s") => Get the specified object',
+      async (key) =>
+        expect((await func()).position.getByKey(key)).toEqual({
+          detail: expect.any(String),
+          more: expect.any(Array),
+          name: expect.any(String),
+        })
+    );
+  });
+  describe('`Accessors.position.getCategoryDetail()` method', () => {
+    it('Get the specified object', async () =>
+      expect((await func()).position.getCategoryDetail()).toEqual({
+        detail: expect.any(String),
+        name: expect.any(String),
+      }));
+  });
+  describe('`Accessors.response.getByKey()` method', () => {
+    it.each<Response>(['action', 'mind'])(
+      '("%s") => Get the specified object',
+      async (key) =>
+        expect((await func()).response.getByKey(key)).toEqual({
+          detail: expect.any(String),
+          more: expect.any(Array),
+          name: expect.any(String),
+        })
+    );
+  });
+  describe('`Accessors.response.getCategoryDetail()` method', () => {
+    it('Get the specified object', async () =>
+      expect((await func()).response.getCategoryDetail()).toEqual({
+        detail: expect.any(String),
+        name: expect.any(String),
+      }));
+  });
+  describe('`Accessors.vector.getByKey()` method', () => {
+    it.each<Vector>(['authority', 'economically', 'humanely'])(
+      '("%s") => Get the specified object',
+      async (key) =>
+        expect((await func()).vector.getByKey(key)).toEqual({
+          detail: expect.any(Array),
+          name: expect.any(String),
+          strategy: expect.any(Array),
+        })
+    );
+  });
+  describe('`Accessors.vector.getCategoryDetail()` method', () => {
+    it('Get the specified object', async () =>
+      expect((await func()).vector.getCategoryDetail()).toEqual({
+        detail: expect.any(String),
+        name: expect.any(String),
+      }));
+  });
+});

--- a/packages/dantalion-i18n/src/resources/createAccessorsAsync.ts
+++ b/packages/dantalion-i18n/src/resources/createAccessorsAsync.ts
@@ -1,0 +1,129 @@
+import type { ResourceLanguage, TFunction, WithT } from 'i18next';
+import type {
+  Brain,
+  Communication,
+  Genius,
+  LifeBase,
+  Management,
+  Motivation,
+  Position,
+  Response,
+  Vector,
+} from '@kurone-kito/dantalion-core';
+import createGenericAccessor, { DetailAccessor } from './createGenericAccessor';
+import createTAsync from './createTAsync';
+import type {
+  DesctiptionsType,
+  DetailsType,
+  PersonalityDetailType,
+  PersonalityType,
+  VectorType,
+} from './types';
+
+/** The type definition of the concreted accessors collection */
+export interface Accessors {
+  /**
+   * The instance provides a set of functions that retrieve
+   * human-readable resources related to the thought method.
+   */
+  readonly brain: DetailAccessor<DetailsType, Brain>;
+
+  /**
+   * The instance provides a set of functions that retrieve
+   * human-readable resources related to dialogue policy.
+   */
+  readonly communication: DetailAccessor<DetailsType, Communication>;
+
+  /**
+   * The instance provides a set of functions that retrieve
+   * human-readable resources related to natural personality.
+   */
+  readonly genius: DetailAccessor<
+    PersonalityType,
+    Genius,
+    PersonalityDetailType
+  >;
+
+  /** Get the resources of the descriptions heading. */
+  readonly getDescription: (
+    /** The genius type or birthday */
+    type?: string
+  ) => DesctiptionsType;
+
+  /**
+   * The instance provides a set of functions that retrieve
+   * human-readable resources related to the base of ego type.
+   */
+  readonly lifeBase: DetailAccessor<string, LifeBase, string>;
+
+  /**
+   * The instance provides a set of functions that retrieve human-readable
+   * resources related to risk and return thinking in specific people.
+   */
+  readonly management: DetailAccessor<DetailsType, Management>;
+
+  /**
+   * The instance provides a set of functions that retrieve human-readable
+   * resources related to an environment that is easy to get motivated.
+   */
+  readonly motivation: DetailAccessor<string, Motivation, string>;
+
+  /**
+   * The instance provides a set of functions that retrieve
+   * human-readable resources related to a talented role.
+   */
+  readonly position: DetailAccessor<DetailsType, Position>;
+
+  /**
+   * The instance provides a set of functions that retrieve
+   * human-readable resources related to on-site or behind.
+   */
+  readonly response: DetailAccessor<DetailsType, Response>;
+
+  /**
+   * The instance provides a set of functions that retrieve human-readable
+   * resources related to the major classification of personality.
+   */
+  readonly vector: DetailAccessor<VectorType, Vector>;
+}
+
+/**
+ * Create the concreted accessors collection from the i18next instance
+ * @param t Specify the i18next instance
+ * @returns The instance of the concreted accessors collection
+ */
+export const createAccessors = (t: TFunction): Accessors => {
+  const { tDetail, tObj, tStringedDetail } = createGenericAccessor(t);
+  return {
+    brain: tDetail<DetailsType, Brain>('brain'),
+    communication: tDetail<DetailsType, Communication>('communication'),
+    genius: tDetail<PersonalityType, Genius, PersonalityDetailType>('genius'),
+    getDescription: (type?: string) => tObj('descriptions', { type }),
+    lifeBase: tStringedDetail('lifeBase'),
+    management: tDetail<DetailsType, Management>('management'),
+    motivation: tStringedDetail('motivation'),
+    position: tDetail<DetailsType, Position>('position'),
+    response: tDetail<DetailsType, Response>('response'),
+    vector: tDetail<VectorType, Vector>('vector'),
+  };
+};
+
+/**
+ * Create the concreted accessors collection asynchronously
+ *
+ * It is a synonym function that combines
+ * `createAccessors()` and `createTAsync()`.
+ * @param lng The language.
+ *
+ * If omitted, the language used is detected from the current environment.
+ * @param addition The additional resources.
+ * @returns The instance of the concreted accessors collection asynchronously
+ * @see useLocale()
+ */
+export default async (
+  lng?: string,
+  addition?: ResourceLanguage
+): Promise<Accessors & WithT> => {
+  const t = await createTAsync(lng, addition);
+  return { ...createAccessors(t), t };
+};

--- a/packages/dantalion-i18n/src/resources/createTAsync.spec.ts
+++ b/packages/dantalion-i18n/src/resources/createTAsync.spec.ts
@@ -1,0 +1,6 @@
+import createTAsync from './createTAsync';
+
+describe('`createTAsync()` function', () => {
+  it('Get the function', async () =>
+    expect(await createTAsync()).toEqual(expect.any(Function)));
+});


### PR DESCRIPTION
## **BREAKING CHANGE**

- i18n: Some API will be deprecated. They will no longer the next update.

| Category | Deprecated                      | Migrate to                   |
| :------- | :------------------------------ | :--------------------------- |
| Function | `getDescriptionAsync()`         | `Accessors.getDescription()` |
| Function | `getDetailMarkdownAsync()`      | `getDetailMarkdown()`        |
| Function | `getPersonalityMarkdownAsync()` | `getPersonalityMarkdown()`   |
| Property | `brain`                         | `Accessors.brain`            |
| Property | `communication`                 | `Accessors.communication`    |
| Property | `genius`                        | `Accessors.genius`           |
| Property | `lifeBase`                      | `Accessors.lifeBase`         |
| Property | `management`                    | `Accessors.management`       |
| Property | `motivation`                    | `Accessors.motivation`       |
| Property | `position`                      | `Accessors.position`         |
| Property | `response`                      | `Accessors.response`         |
| Property | `vector`                        | `Accessors.vector`           |
| Type     | `ResourcesAccessor<T, K, D>`    | `DetailAccessor<T, K, D>`    |

## Feature

- i18n: Added the some functions, types.
  - `Accessors` / `createAccessors()` / `createAccessorsAsync()` (97058ff)
  - `getDetailMarkdown()` / `getPersonalityMarkdown` (e57462a)
- i18n: Added the argument to `createTAsync()` function. (62e3558)
- migrated to new accessors at the logic of build Markdown API. (6b1a0db)

## Tests

- i18n: Added the `createTAsync()` function (98084e2)

## Docs

- i18n: replaced the example result to the English version (603d834)
