### PR TITLE
No longer supported in Node.js < 12.1; Removed the depends directly on environment variables for getting locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The app can specify a birthday within the range from February 1, 1873, to Decemb
 
 ## Usage
 
-Require: Node.js >= v12
+Require: Node.js >= v12.1
 
 ### For those who want to use this app with CLI
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1382,28 +1382,28 @@
 			}
 		},
 		"@nodelib/fs.scandir": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
-			"integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
 			"dev": true,
 			"requires": {
-				"@nodelib/fs.stat": "2.0.4",
+				"@nodelib/fs.stat": "2.0.5",
 				"run-parallel": "^1.1.9"
 			}
 		},
 		"@nodelib/fs.stat": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
-			"integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
 			"dev": true
 		},
 		"@nodelib/fs.walk": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
-			"integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.7.tgz",
+			"integrity": "sha512-BTIhocbPBSrRmHxOAJFtR18oLhxTtAFDAvL8hY1S3iU8k+E60W/YFs4jrixGzQjMpF4qPXxIQHcjVD9dz1C2QA==",
 			"dev": true,
 			"requires": {
-				"@nodelib/fs.scandir": "2.1.4",
+				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
 			}
 		},
@@ -1623,9 +1623,9 @@
 			}
 		},
 		"@octokit/openapi-types": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.2.3.tgz",
-			"integrity": "sha512-V1ycxkR19jqbIl3evf2RQiMRBvTNRi+Iy9h20G5OP5dPfEF6GJ1DPlUeiZRxo2HJxRr+UA4i0H1nn4btBDPFrw==",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.3.0.tgz",
+			"integrity": "sha512-o00X2FCLiEeXZkm1Ab5nvPUdVOlrpediwWZkpizUJ/xtZQsJ4FiQ2RB/dJEmb0Nk+NIz7zyDePcSCu/Y/0M3Ew==",
 			"dev": true
 		},
 		"@octokit/plugin-enterprise-rest": {
@@ -1660,14 +1660,14 @@
 			}
 		},
 		"@octokit/request": {
-			"version": "5.4.15",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.15.tgz",
-			"integrity": "sha512-6UnZfZzLwNhdLRreOtTkT9n57ZwulCve8q3IT/Z477vThu6snfdkBuhxnChpOKNGxcQ71ow561Qoa6uqLdPtag==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.5.0.tgz",
+			"integrity": "sha512-jxbMLQdQ3heFMZUaTLSCqcKs2oAHEYh7SnLLXyxbZmlULExZ/RXai7QUWWFKowcGGPlCZuKTZg0gSKHWrfYEoQ==",
 			"dev": true,
 			"requires": {
 				"@octokit/endpoint": "^6.0.1",
 				"@octokit/request-error": "^2.0.0",
-				"@octokit/types": "^6.7.1",
+				"@octokit/types": "^6.16.1",
 				"is-plain-object": "^5.0.0",
 				"node-fetch": "^2.6.1",
 				"universal-user-agent": "^6.0.0"
@@ -1970,9 +1970,9 @@
 			}
 		},
 		"before-after-hook": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.1.tgz",
-			"integrity": "sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+			"integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
 			"dev": true
 		},
 		"brace-expansion": {
@@ -2321,9 +2321,9 @@
 			}
 		},
 		"config-chain": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
-			"integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+			"integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
 			"dev": true,
 			"requires": {
 				"ini": "^1.3.4",
@@ -2894,9 +2894,9 @@
 			"dev": true
 		},
 		"execa": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.0.tgz",
-			"integrity": "sha512-CkdUB7s2y6S+d4y+OM/+ZtQcJCiKUCth4cNImGMqrt2zEVtW2rfHGspQBE1GDo6LjeNIQmTPKXqTCKjqFKyu3A==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
 			"dev": true,
 			"requires": {
 				"cross-spawn": "^7.0.3",
@@ -4281,9 +4281,9 @@
 			}
 		},
 		"make-fetch-happen": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.0.1.tgz",
-			"integrity": "sha512-c2IxuRxsPKpW9ftCUnsbbAD3rBZNGsuRNwexAbWI8Eh9jlEVPrxZYK5ffgYRAVTQBegqrqR3DlWrsvvLhi4xQA==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.0.2.tgz",
+			"integrity": "sha512-UkAWAuXPXSSlVviTjH2We20mtj1NnZW2Qq/oTY2dyMbRQ5CR3Xed3akCDMnM7j6axrMY80lhgM7loNE132PfAw==",
 			"dev": true,
 			"requires": {
 				"agentkeepalive": "^4.1.3",
@@ -6404,9 +6404,9 @@
 			}
 		},
 		"uglify-js": {
-			"version": "3.13.8",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.8.tgz",
-			"integrity": "sha512-PvFLMFIQHfIjFFlvAch69U2IvIxK9TNzNWt1SxZGp9JZ/v70yvqIQuiJeVPPtUMOzoNt+aNRDk4wgxb34wvEqA==",
+			"version": "3.13.9",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.9.tgz",
+			"integrity": "sha512-wZbyTQ1w6Y7fHdt8sJnHfSIuWeDgk6B5rCb4E/AM6QNNPbOMIZph21PW5dRB3h7Df0GszN+t7RuUH6sWK5bF0g==",
 			"dev": true,
 			"optional": true
 		},

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "npm-run-all": "^4.1.5"
   },
   "engines": {
-    "node": ">=12 <13 || >=14"
+    "node": ">=12.1"
   },
   "private": true,
   "publishConfig": {

--- a/packages/dantalion-cli/package.json
+++ b/packages/dantalion-cli/package.json
@@ -63,7 +63,7 @@
     "typescript": "^4.3.2"
   },
   "engines": {
-    "node": ">=12.1 <13 || >=14"
+    "node": ">=12.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/dantalion-cli/package.json
+++ b/packages/dantalion-cli/package.json
@@ -47,9 +47,9 @@
     "@types/jest": "^26.0.23",
     "@types/marked": "^2.0.3",
     "@types/marked-terminal": "^3.1.1",
-    "@typescript-eslint/eslint-plugin": "^4.26.0",
-    "@typescript-eslint/parser": "^4.26.0",
-    "eslint": "^7.27.0",
+    "@typescript-eslint/eslint-plugin": "^4.26.1",
+    "@typescript-eslint/parser": "^4.26.1",
+    "eslint": "^7.28.0",
     "eslint-config-airbnb-typescript": "^12.3.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-import-resolver-typescript": "^2.4.0",
@@ -58,8 +58,8 @@
     "eslint-plugin-prettier": "^3.4.0",
     "jest": "^27.0.4",
     "jest-cli": "^27.0.4",
-    "prettier": "^2.3.0",
-    "ts-jest": "^27.0.2",
+    "prettier": "^2.3.1",
+    "ts-jest": "^27.0.3",
     "typescript": "^4.3.2"
   },
   "engines": {

--- a/packages/dantalion-core/package.json
+++ b/packages/dantalion-core/package.json
@@ -34,9 +34,9 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",
-    "@typescript-eslint/eslint-plugin": "^4.26.0",
-    "@typescript-eslint/parser": "^4.26.0",
-    "eslint": "^7.27.0",
+    "@typescript-eslint/eslint-plugin": "^4.26.1",
+    "@typescript-eslint/parser": "^4.26.1",
+    "eslint": "^7.28.0",
     "eslint-config-airbnb-typescript": "^12.3.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-import-resolver-typescript": "^2.4.0",
@@ -45,8 +45,8 @@
     "eslint-plugin-prettier": "^3.4.0",
     "jest": "^27.0.4",
     "jest-cli": "^27.0.4",
-    "prettier": "^2.3.0",
-    "ts-jest": "^27.0.2",
+    "prettier": "^2.3.1",
+    "ts-jest": "^27.0.3",
     "typescript": "^4.3.2"
   },
   "engines": {

--- a/packages/dantalion-core/package.json
+++ b/packages/dantalion-core/package.json
@@ -50,7 +50,7 @@
     "typescript": "^4.3.2"
   },
   "engines": {
-    "node": ">=12 <13 || >=14"
+    "node": ">=12"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/dantalion-i18n/README.md
+++ b/packages/dantalion-i18n/README.md
@@ -139,25 +139,17 @@ The string that the personality information as the Markdown format.
 If you specified the `undefined` value as an argument or omitted it,
 it would be a list of the available types.
 
-### `getLocale(forceEnv?: boolean): string | undefined`
+### `getLocale(): string | undefined`
 
-It provides the appropriate locale information acquisition function
-according to the current environment.
-
-For Node.js version `12.1.0` and later or web browsers, it depends on the
-[Intl API](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl)'s
-decision. If not, it determines by the environment variables.
+Get the locale information from the Intl API.
 
 #### Arguments
 
-| Name       | Type                   | Defaults  | Description                                                                                            |
-| :--------- | :--------------------- | :-------- | :----------------------------------------------------------------------------------------------------- |
-| `forceEnv` | `boolean \| undefined` | undefined | If the value is truthy, the function selects the getting forcibly that from the environment variables. |
+(None)
 
 #### Returns
 
-`string | undefined`: The locale string e.g. `en-US` or `en_US.UTF-8`.
-If it is not recognized correctly, it may return an undefined value.
+`string`: The locale string e.g. `en-US`.
 
 ### `getPersonalityMarkdown(accessors: Accessors, birth: string | number | Date): string`
 

--- a/packages/dantalion-i18n/package.json
+++ b/packages/dantalion-i18n/package.json
@@ -59,7 +59,7 @@
     "typescript": "^4.3.2"
   },
   "engines": {
-    "node": ">=12.1 <13 || >=14"
+    "node": ">=12.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/dantalion-i18n/package.json
+++ b/packages/dantalion-i18n/package.json
@@ -36,16 +36,14 @@
   "dependencies": {
     "@kurone-kito/dantalion-core": "^0.14.0",
     "i18next": "^20.3.1",
-    "lodash.merge": "^4.6.2",
-    "semver": "^7.3.5"
+    "lodash.merge": "^4.6.2"
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",
     "@types/lodash.merge": "^4.6.6",
-    "@types/semver": "^7.3.6",
-    "@typescript-eslint/eslint-plugin": "^4.26.0",
-    "@typescript-eslint/parser": "^4.26.0",
-    "eslint": "^7.27.0",
+    "@typescript-eslint/eslint-plugin": "^4.26.1",
+    "@typescript-eslint/parser": "^4.26.1",
+    "eslint": "^7.28.0",
     "eslint-config-airbnb-typescript": "^12.3.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-import-resolver-typescript": "^2.4.0",
@@ -54,8 +52,8 @@
     "eslint-plugin-prettier": "^3.4.0",
     "jest": "^27.0.4",
     "jest-cli": "^27.0.4",
-    "prettier": "^2.3.0",
-    "ts-jest": "^27.0.2",
+    "prettier": "^2.3.1",
+    "ts-jest": "^27.0.3",
     "typescript": "^4.3.2"
   },
   "engines": {

--- a/packages/dantalion-i18n/src/getLocale.spec.ts
+++ b/packages/dantalion-i18n/src/getLocale.spec.ts
@@ -1,14 +1,7 @@
 import getLocale from './getLocale';
 
 describe('`getLocale()` function', () => {
-  describe.each([false, undefined])('getLocale(%p)', (forceEnv) => {
-    it('Get the string', () =>
-      expect(getLocale(forceEnv)).toEqual(expect.any(String)));
-    it('Get the same value', () =>
-      expect(getLocale(forceEnv)).toBe(getLocale()));
-  });
-  describe('getLocale(true)', () => {
-    it('Get the string', () =>
-      expect(getLocale(true)).toEqual(expect.any(String)));
+  describe('getLocale()', () => {
+    it('Get the string', () => expect(getLocale()).toEqual(expect.any(String)));
   });
 });

--- a/packages/dantalion-i18n/src/getLocale.ts
+++ b/packages/dantalion-i18n/src/getLocale.ts
@@ -1,47 +1,5 @@
-import semverGte from 'semver/functions/gte';
-
 /**
  * Get the locale information from the Intl API.
- *
- * If the environment is on NodeJS and does not have Full-ICU,
- * it may get the default results.
  * @returns The locale string e.g. `en-US`.
  */
-const getLocaleFromIntlApi = () =>
-  Intl.DateTimeFormat().resolvedOptions().locale;
-
-/**
- * Get the locale information from the environment variables.
- * @returns The locale string e.g. `en_US.UTF-8`.
- */
-const getLocaleFromEnv = () => {
-  const { env } = process;
-  return env.LC_ALL || env.LC_MESSAGES || env.LANG || env.LANGUAGE;
-};
-
-/**
- * Detect the current environment is on the NodeJS v12._1_.x or upper.
- *
- * In NodeJS v12 or later, it can get correct locale information from
- * Intl API. But also, v12._0_.x has a problem in Intl API.
- */
-const isAvailableDefaultNodeICU = () => semverGte(process.version, '12.1.0');
-
-/** Detect the current environment is on the browser. */
-const isBrowser = () =>
-  // eslint-disable-next-line @typescript-eslint/no-implied-eval
-  !!new Function(
-    'try { return this === window; } catch (e) { return false; }'
-  )();
-
-/**
- * It provides the appropriate locale information acquisition
- * function according to the current environment.
- * @param forceEnv If the value is truthy, the function selects
- * the getting forcibly that from the environment variables.
- * @returns The locale string e.g. `en-US` or `en_US.UTF-8`.
- */
-export default (forceEnv?: boolean): string =>
-  ((forceEnv || !(isBrowser() || isAvailableDefaultNodeICU())) &&
-    getLocaleFromEnv()) ||
-  getLocaleFromIntlApi();
+export default (): string => Intl.DateTimeFormat().resolvedOptions().locale;

--- a/packages/dantalion-web-playground/package.json
+++ b/packages/dantalion-web-playground/package.json
@@ -59,8 +59,6 @@
     "unstated-next": "^1.1.0"
   },
   "devDependencies": {
-    "@storybook/addon-actions": "^6.2.9",
-    "@storybook/addon-docs": "^6.2.9",
     "@storybook/addon-essentials": "^6.2.9",
     "@storybook/addon-postcss": "^2.0.0",
     "@storybook/builder-webpack5": "^6.2.9",
@@ -69,9 +67,9 @@
     "@types/qs": "^6.9.6",
     "@types/react": "^17.0.9",
     "@types/react-fontawesome": "^1.6.4",
-    "@typescript-eslint/eslint-plugin": "^4.26.0",
-    "@typescript-eslint/parser": "^4.26.0",
-    "eslint": "^7.27.0",
+    "@typescript-eslint/eslint-plugin": "^4.26.1",
+    "@typescript-eslint/parser": "^4.26.1",
+    "eslint": "^7.28.0",
     "eslint-config-airbnb-typescript": "^12.3.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-import-resolver-typescript": "^2.4.0",
@@ -82,8 +80,8 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.3.0",
-    "prettier": "^2.3.0",
-    "serve": "^11.3.2",
+    "prettier": "^2.3.1",
+    "serve": "^12.0.0",
     "stylelint": "^13.13.1",
     "stylelint-config-recommended": "^5.0.0",
     "typescript": "^4.3.2"

--- a/packages/dantalion-web-playground/package.json
+++ b/packages/dantalion-web-playground/package.json
@@ -89,7 +89,7 @@
     "typescript": "^4.3.2"
   },
   "engines": {
-    "node": ">=12.1 <13 || >=14"
+    "node": ">=12.1"
   },
   "private": true,
   "publishConfig": {


### PR DESCRIPTION
## BREAKING CHANGES

- cli, i18n: No longer supported in Node.js < 12.1 (a1311ad)
  - Node.js < v11 and v12.0 could not work the Intl API correctly, so this library has an option that depends directly on environment variables.
    However, that support only increases the complexity of the library and has minimal benefit, so it removes in this update.
- i18n: Removed an argument of `getLocale()` function. (3ab0248)
  - The arguments for this function no longer have any meaning.
    In particular, if you rely on this function in your TypeScript environment, you may need to fix it as soon as possible.
  - It always uses the [Intl API](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) and no longer depends directly on environment variables.

## Refactors

- i18n: Updated and removed the dependencies. (877cad0)
