### PR TITLE
chore: complete push-main.yml content rename

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -1,8 +1,8 @@
-name: CI/CD on master branch
+name: CI/CD on main branch
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
 jobs:
   deploy:
     name: Build and deploy


### PR DESCRIPTION
Follow-up to #99 — the rename was staged before the content edit, so the workflow's `name` and `branches` filter still referenced `master`. Without this change the deploy workflow on `main` listens for pushes to `master` which no longer exists.

Refs #80