### PR TITLE
feat(i18n)!: rename exported type DesctiptionsType to DescriptionsType

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -11,7 +11,6 @@ words:
   - coef
   - dantalion
   - dcoef
-  - desctiption
   - desctiptions
   - esync
   - febrary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ First stable release on the modernized toolchain.
   sometimes documented as `potential` (singular) in v0.19.x
   READMEs. The runtime field name has always been `potentials`;
   the documentation now matches.
+- **`@kurone-kito/dantalion-i18n`** renames the exported type
+  `DesctiptionsType` → `DescriptionsType` (transposed-letter typo
+  fix). Consumers referencing the type by name in their own
+  TypeScript code must rename. The runtime shape is unchanged.
 
 ### Features
 
@@ -55,9 +59,6 @@ First stable release on the modernized toolchain.
 - **commander / marked / marked-terminal major bumps**
   (`@kurone-kito/dantalion-cli`): pinned at v7 / v2 / v4
   respectively because v12 / v15 / v7 require API rewrites.
-- **`DesctiptionsType` → `DescriptionsType`** typo fix in exported
-  type names: deferred because the rename is a breaking change
-  beyond the v1.0.0 scope.
 
 ---
 

--- a/packages/dantalion-i18n/README.md
+++ b/packages/dantalion-i18n/README.md
@@ -220,7 +220,7 @@ interface Accessors {
   >;
   readonly response: DetailAccessor<DetailsType, Response>;
   readonly vector: DetailAccessor<VectorType, Vector>;
-  getDescription(type?: string): DesctiptionsType;
+  getDescription(type?: string): DescriptionsType;
 }
 ```
 
@@ -239,7 +239,7 @@ interface Accessors {
 
 | Method definition                                 | Description                                    |
 | :------------------------------------------------ | :--------------------------------------------- |
-| `getDescription(type?: string): DesctiptionsType` | Get the resources of the descriptions heading. |
+| `getDescription(type?: string): DescriptionsType` | Get the resources of the descriptions heading. |
 
 ### `CreateTAsyncOptions`
 
@@ -265,12 +265,12 @@ interface CreateTAsyncOptions {
 
 (\*: See the type definition as it is long :/)
 
-### `DesctiptionsType`
+### `DescriptionsType`
 
 The type definition that the resources of description.
 
 ```ts
-interface DesctiptionsType {
+interface DescriptionsType {
   readonly cc: string;
   readonly detail: string;
   readonly details: string;

--- a/packages/dantalion-i18n/src/build/genius.ts
+++ b/packages/dantalion-i18n/src/build/genius.ts
@@ -1,6 +1,6 @@
 import type { Personality } from '@kurone-kito/dantalion-core';
 import type { Accessors } from '../resources/createAccessorsAsync.js';
-import type { DesctiptionsType, PersonalityType } from '../resources/types.js';
+import type { DescriptionsType, PersonalityType } from '../resources/types.js';
 import type { Options } from './article.js';
 import article from './article.js';
 import { detailsBase } from './details.js';
@@ -26,8 +26,8 @@ const fromGeniusOnlySummary = (
  * @param source The source.
  * @param level The heading level.
  */
-const fromGeniusOnlyDesctiption = (
-  { strategy, weak }: Pick<DesctiptionsType, 'strategy' | 'weak'>,
+const fromGeniusOnlyDescription = (
+  { strategy, weak }: Pick<DescriptionsType, 'strategy' | 'weak'>,
   source: Pick<PersonalityType, 'strategy' | 'weak'>,
   level?: number,
 ) =>
@@ -43,7 +43,7 @@ const fromGeniusOnlyDesctiption = (
  * @param descriptions The resource of tne description.
  */
 export const createFromGenius =
-  (descriptions: Pick<DesctiptionsType, 'strategy' | 'weak'>) =>
+  (descriptions: Pick<DescriptionsType, 'strategy' | 'weak'>) =>
   /**
    * @param source The source.
    * @param level The heading level.
@@ -51,7 +51,7 @@ export const createFromGenius =
   (source: PersonalityType, level: number): string =>
     line(
       fromGeniusOnlySummary(source, level),
-      fromGeniusOnlyDesctiption(descriptions, source, level + 1),
+      fromGeniusOnlyDescription(descriptions, source, level + 1),
     );
 
 /**

--- a/packages/dantalion-i18n/src/index.ts
+++ b/packages/dantalion-i18n/src/index.ts
@@ -13,7 +13,7 @@ export {
   locales,
 } from './resources/createTAsync.js';
 export type {
-  DesctiptionsType,
+  DescriptionsType,
   DetailsBaseType,
   DetailsType,
   PersonalityDetailBaseType,

--- a/packages/dantalion-i18n/src/resources/createAccessorsAsync.ts
+++ b/packages/dantalion-i18n/src/resources/createAccessorsAsync.ts
@@ -15,7 +15,7 @@ import type { DetailAccessor } from './createGenericAccessor.js';
 import createGenericAccessor from './createGenericAccessor.js';
 import createTAsync from './createTAsync.js';
 import type {
-  DesctiptionsType,
+  DescriptionsType,
   DetailsBaseType,
   DetailsType,
   PersonalityDetailType,
@@ -51,7 +51,7 @@ export interface Accessors {
   readonly getDescription: (
     /** The genius type or birthday */
     type?: string,
-  ) => DesctiptionsType;
+  ) => DescriptionsType;
 
   /**
    * The instance provides a set of functions that retrieve

--- a/packages/dantalion-i18n/src/resources/types.ts
+++ b/packages/dantalion-i18n/src/resources/types.ts
@@ -1,5 +1,5 @@
 /** The type definition that the resources of description. */
-export interface DesctiptionsType {
+export interface DescriptionsType {
   /** The title of personality code. */
   readonly cc: string;
   /** The title of the detail. */


### PR DESCRIPTION
Closes #135 / Refs #137.

Mechanical typo fix in the public type exports of `@kurone-kito/dantalion-i18n` before v1.0.0 publishes. Runtime shape unchanged; only TS consumers referencing the type name see a rename.

## Test plan
- [x] Build + 497 tests + 100% line coverage pass locally
- [x] `dist/index.d.ts` now exports `DescriptionsType`
- [x] CHANGELOG v1.0.0 BREAKING CHANGES updated
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Fixed type name spelling in `@kurone-kito/dantalion-i18n`: Users must update code referencing the old type name to use the corrected spelling.

* **Documentation**
  * Updated package documentation to reflect corrected type names and method signatures.

* **Chores**
  * Updated spell-check configuration allowlist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->