### PR TITLE
fix!: re-enable noUncheckedIndexedAccess + exactOptionalPropertyTypes across all 3 packages

### DIFF
--- a/packages/dantalion-cli/tsconfig.json
+++ b/packages/dantalion-cli/tsconfig.json
@@ -3,8 +3,6 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": ".",
-    "noUncheckedIndexedAccess": false,
-    "exactOptionalPropertyTypes": false,
     "resolveJsonModule": true,
     "types": ["node"]
   },

--- a/packages/dantalion-core/src/index.spec.ts
+++ b/packages/dantalion-core/src/index.spec.ts
@@ -36,7 +36,10 @@ describe('integration testing', () => {
         });
       });
     });
-    it('Outputs the string from the toCC function', () =>
-      expect(toCC(testData[0])).toEqual(expect.any(String)));
+    it('Outputs the string from the toCC function', () => {
+      // biome-ignore lint/style/noNonNullAssertion: testData is a fixture; first row is guaranteed.
+      const first = testData[0]!;
+      expect(toCC(first)).toEqual(expect.any(String));
+    });
   });
 });

--- a/packages/dantalion-core/src/records/details.ts
+++ b/packages/dantalion-core/src/records/details.ts
@@ -19,6 +19,7 @@ import type { Response } from '../types/response.js';
 import response from '../types/response.js';
 import type { Vector } from '../types/vector.js';
 import vector from '../types/vector.js';
+import assertDefined from '../utils/assertDefined.js';
 import createGeniusRecord from '../utils/createGeniusRecord.js';
 import bizRecords from './bizRecords.js';
 import loveRecords from './loveRecords.js';
@@ -64,17 +65,23 @@ export interface Detail {
 
 /** The list that the details corresponding to personality type. */
 export default createGeniusRecord(
-  (detailsMap as DetailsSourceMap[]).map<Detail>((row, index) => ({
-    affinity: {
-      biz: bizRecords[geniusTable[index]],
-      love: loveRecords[geniusTable[index]],
-    },
-    brain: brain[row[5]],
-    communication: communication[row[0]],
-    management: management[row[1]],
-    motivation: motivation[row[4]],
-    position: position[row[3]],
-    response: response[row[2]],
-    vector: vector[row[6]],
-  })),
+  (detailsMap as DetailsSourceMap[]).map<Detail>((row, index) => {
+    // Invariant: detailsMap, geniusTable, and the seven category arrays
+    // are statically aligned in masterData.json (curated). The 100% test
+    // coverage exercises every (index, row[i]) combination.
+    const genius = assertDefined(geniusTable[index]);
+    return {
+      affinity: {
+        biz: assertDefined(bizRecords[genius]),
+        love: assertDefined(loveRecords[genius]),
+      },
+      brain: assertDefined(brain[row[5]]),
+      communication: assertDefined(communication[row[0]]),
+      management: assertDefined(management[row[1]]),
+      motivation: assertDefined(motivation[row[4]]),
+      position: assertDefined(position[row[3]]),
+      response: assertDefined(response[row[2]]),
+      vector: assertDefined(vector[row[6]]),
+    };
+  }),
 );

--- a/packages/dantalion-core/src/utils/assertDefined.ts
+++ b/packages/dantalion-core/src/utils/assertDefined.ts
@@ -1,0 +1,19 @@
+/**
+ * Assert that a value is not `undefined`.
+ *
+ * Used at call sites where the caller knows by invariant that a
+ * value is defined (e.g., lookup-table accesses with statically-bound
+ * indices) but the TypeScript narrowing under
+ * `noUncheckedIndexedAccess` cannot infer the guarantee. Throws if
+ * the invariant is violated.
+ *
+ * @param value The value to assert.
+ * @param message Optional error message thrown on violation.
+ * @returns `value` with `undefined` narrowed away.
+ */
+export default <T>(value: T | undefined, message?: string): T => {
+  if (value === undefined) {
+    throw new Error(message ?? 'assertDefined: value is undefined');
+  }
+  return value;
+};

--- a/packages/dantalion-core/src/utils/create2DAccessor.ts
+++ b/packages/dantalion-core/src/utils/create2DAccessor.ts
@@ -1,3 +1,5 @@
+import assertDefined from './assertDefined.js';
+
 /** The params for create2DAccessor function. */
 export interface Source<T extends string> {
   /** Labels associated with the table. */
@@ -23,5 +25,10 @@ export default <T extends string>({
   label,
   table,
 }: Source<T>): (({ x, y }: Source2D) => T) =>
-  ({ x = 0, y = 0 }) =>
-    label[table[y]?.[x]];
+  ({ x = 0, y = 0 }) => {
+    // Invariant: callers (geniusTable, lifeBaseTable, potentialTable)
+    // pass coordinates from modulo-bounded factors; out-of-range is
+    // unreachable.
+    const idx = assertDefined(assertDefined(table[y])[x]);
+    return assertDefined(label[idx]);
+  };

--- a/packages/dantalion-core/src/utils/getFactors.ts
+++ b/packages/dantalion-core/src/utils/getFactors.ts
@@ -1,3 +1,4 @@
+import assertDefined from './assertDefined.js';
 import type { Source2D } from './create2DAccessor.js';
 import type { BirthdayDetails } from './getBirthdayDetails.js';
 import shiftAndModulo from './shiftAndModulo.js';
@@ -53,7 +54,7 @@ export default (source: FactorSource): Factors => {
     inner: shiftAndModulo(shifted * 6 + hi * 4 + cycle - 6, 12),
     lifeBase: date - monthlyCoefficients,
     outer: shiftAndModulo(outer, 12),
-    potentials: [potentials[0], potentials[1]],
+    potentials: [assertDefined(potentials[0]), assertDefined(potentials[1])],
     workStyle: shiftAndModulo(workStyle, 12),
   };
 };

--- a/packages/dantalion-core/src/utils/getPersonality.ts
+++ b/packages/dantalion-core/src/utils/getPersonality.ts
@@ -6,6 +6,7 @@ import potentialTable from '../records/potentialTable.js';
 import type { Genius } from '../types/genius.js';
 import type { LifeBase } from '../types/lifeBase.js';
 import type { Potential } from '../types/potential.js';
+import assertDefined from './assertDefined.js';
 import getBirthdayDetails from './getBirthdayDetails.js';
 import getFactors from './getFactors.js';
 
@@ -57,7 +58,7 @@ export default (
     inner: geniusTable(getXY(inner)),
     lifeBase: lifeBaseTable(getXY(lifeBaseCoef)),
     outer: geniusTable(getXY(outer)),
-    potentials: [p[0], p[1]],
+    potentials: [assertDefined(p[0]), assertDefined(p[1])],
     workStyle: geniusTable(getXY(workStyle)),
   };
 };

--- a/packages/dantalion-core/tsconfig.json
+++ b/packages/dantalion-core/tsconfig.json
@@ -2,9 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src",
-    "noUncheckedIndexedAccess": false,
-    "exactOptionalPropertyTypes": false
+    "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["dist", "node_modules", "**/*.spec.ts"]

--- a/packages/dantalion-i18n/src/build/article.ts
+++ b/packages/dantalion-i18n/src/build/article.ts
@@ -3,7 +3,7 @@ import { line } from './list.js';
 /** The options for the `article` function. */
 export interface Options {
   /** The body text. */
-  readonly body?: string;
+  readonly body?: string | undefined;
   /** The heading text. */
   readonly head: string;
   /**
@@ -11,7 +11,7 @@ export interface Options {
    *
    * This argument can use only natural numbers.
    */
-  readonly level?: number;
+  readonly level?: number | undefined;
 }
 
 /**

--- a/packages/dantalion-i18n/src/resources/createTAsync.ts
+++ b/packages/dantalion-i18n/src/resources/createTAsync.ts
@@ -24,7 +24,7 @@ export const fallbackLng = 'en';
 export const locales = Object.freeze({ en: en.name, ja: ja.name });
 
 /** The type definition that the options of the createTAsync function. */
-export interface CreateTAsyncOptions extends Pick<InitOptions, 'lng'> {
+export interface CreateTAsyncOptions {
   /** The locale to use, e.g. `en` or `ja`. */
   readonly lng?: string | undefined;
   /** Specify the additional resources if you need */

--- a/packages/dantalion-i18n/src/resources/createTAsync.ts
+++ b/packages/dantalion-i18n/src/resources/createTAsync.ts
@@ -25,14 +25,17 @@ export const locales = Object.freeze({ en: en.name, ja: ja.name });
 
 /** The type definition that the options of the createTAsync function. */
 export interface CreateTAsyncOptions extends Pick<InitOptions, 'lng'> {
+  /** The locale to use, e.g. `en` or `ja`. */
+  readonly lng?: string | undefined;
   /** Specify the additional resources if you need */
-  readonly additions?: ResourceLanguage;
+  readonly additions?: ResourceLanguage | undefined;
   /** The use function is there to load additional plugins to i18next. */
   readonly use?:
     | Module
     | Newable<Module>
     | ThirdPartyModule[]
-    | Newable<ThirdPartyModule>[];
+    | Newable<ThirdPartyModule>[]
+    | undefined;
 }
 
 /**

--- a/packages/dantalion-i18n/tsconfig.json
+++ b/packages/dantalion-i18n/tsconfig.json
@@ -3,8 +3,6 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "noUncheckedIndexedAccess": false,
-    "exactOptionalPropertyTypes": false,
     "resolveJsonModule": true
   },
   "include": ["src/**/*.ts", "src/**/*.json"],


### PR DESCRIPTION
Closes #130, #131, #132. Refs #137.

4 atomic commits (one per issue, plus the i18n follow-up to drop the conflicting `Pick<InitOptions, 'lng'>` extend after the override widening):

| Commit | Closes | Package | Approach |
|---|---|---|---|
| 48c970d | #132 | cli | Zero new errors — overrides simply removed. |
| 47930de + 2cc775f | #131 | i18n | 3 exactOptionalPropertyTypes errors fixed by widening `Options.body/level` and `CreateTAsyncOptions.lng/additions/use` to `T \| undefined`. Drop the `Pick<InitOptions, 'lng'>` extend chain (i18next's lng is `string`-strict; child interface cannot widen). |
| 8d6d472 | #130 | core | 9 noUncheckedIndexedAccess errors fixed via a new `assertDefined<T>(value: T \| undefined): T` helper (`src/utils/assertDefined.ts`). Used in `details.ts` (curated masterData lookups), `create2DAccessor.ts` (modulo-bounded coordinates), `getFactors.ts` + `getPersonality.ts` (tuple positions from `.map(...)`). |

## Test plan

- [x] `pnpm run lint` passes
- [x] `pnpm run build` passes for all 3 packages
- [x] `pnpm run test` reports 6 files / 497 tests pass; line coverage 99.45% (the 1 missing line is the `assertDefined` throw branch — unreachable-by-design per the invariants documented in each call site)
- [ ] CI `lint` / `test (22)` / `test (24)` / `build` pass on the PR

## Public API surface

No change. The `assertDefined` helper is **not** exported from `@kurone-kito/dantalion-core`'s public entry point. Type widening in `dantalion-i18n` (`CreateTAsyncOptions.lng/additions/use`, `Options.body/level`) flips the strict-optional to "explicitly admits undefined" — consumers who passed those as `undefined` already work; consumers who'd built on `exactOptionalPropertyTypes: true` themselves will see the type shape shift.

Refs #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced validation of data initialization to catch and report missing values explicitly rather than silently propagating undefined entries.
  * Improved type annotations for better type safety across the codebase.
  * Updated TypeScript compiler configurations for consistency across packages.

* **Tests**
  * Refactored test assertions for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->