### PR TITLE
chore(release): v1.0.0-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ First stable release on the modernized toolchain.
 
 ---
 
-## v1.0.0-rc.0 (unreleased)
+## v1.0.0-rc.0 (2026-05-20)
 
 Release candidate. Identical to v1.0.0 modulo bug fixes from the
 soak window.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurone-kito/dantalion",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-rc.0",
   "description": "Calculates the personality from the birthday using Four Pillars of Destiny (Ba-Zi).",
   "keywords": [
     "ba-zi",

--- a/packages/dantalion-cli/package.json
+++ b/packages/dantalion-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurone-kito/dantalion-cli",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-rc.0",
   "description": "CLI frontend that calculates the personality from the birthday.",
   "keywords": [
     "ba-zi",

--- a/packages/dantalion-core/package.json
+++ b/packages/dantalion-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurone-kito/dantalion-core",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-rc.0",
   "description": "NPM library that calculates the personality from the birthday.",
   "keywords": [
     "ba-zi",

--- a/packages/dantalion-i18n/package.json
+++ b/packages/dantalion-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurone-kito/dantalion-i18n",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-rc.0",
   "description": "Converts results of dantalion into detailed documentation.",
   "keywords": [
     "ba-zi",


### PR DESCRIPTION
Closes step 1 of the 3-step release procedure documented in #95's closing comment.

Bumps all four `package.json` versions to `1.0.0-rc.0`, stamps `CHANGELOG.md` with today's date.

## After merge

Tagging `v1.0.0-rc.0` on `main` will trigger `.github/workflows/release.yml`, which auto-detects the `-rc` qualifier and runs:

```sh
pnpm publish -r --tag next --no-git-checks --access public
```

The three published packages (`@kurone-kito/dantalion-{core,i18n,cli}`) enter the `next` dist-tag — `npm install @kurone-kito/dantalion-cli` continues to resolve to the old (or absent) `latest` until step 3 of #95 promotes `v1.0.0`.

## Test plan

- [x] `pnpm run lint` passes
- [x] `pnpm run test` reports 6 files / 497 tests / 99.45% line coverage
- [x] `pnpm run build` passes
- [x] All 4 package versions consistently at `1.0.0-rc.0`
- [ ] CI passes
- [ ] Tag `v1.0.0-rc.0` after merge triggers `release.yml` publish

Refs #95
Refs #98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.0.0-rc.0 across all packages, marking the transition to the release candidate phase.
  * Changelog updated with the official release candidate date.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->