### PR TITLE
chore(ci): add renovate.json + disable Dependabot via .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,5 @@
+# Dependabot is intentionally disabled in favor of Renovate.
+# See #97 for the rationale; remove this file (or revert to a populated
+# `updates:` list) if reverting to Dependabot for any reason.
+version: 2
+updates: []

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "group:allNonMajor",
+    "schedule:weekly",
+    ":separateMajorReleases",
+    ":semanticCommitsDisabled"
+  ],
+  "commitMessagePrefix": "chore(deps):",
+  "commitMessageAction": "bump",
+  "labels": ["dependencies"],
+  "ignorePaths": ["node_modules/**"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 4am on monday"]
+  },
+  "packageRules": [
+    {
+      "matchPackageNames": ["/^@kurone-kito//"],
+      "groupName": "kurone-kito shared configs"
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true
+    },
+    {
+      "matchPackageNames": ["node"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
Closes #97 / Refs #98.

Lands the configuration files for the Renovate / Dependabot policy switch. The Renovate GitHub App install on `kurone-kito/dantalion` remains as the one maintainer-only step.

## Test plan
- [x] `renovate.json` validates as proper JSON; Biome lint passes
- [x] `.github/dependabot.yml` shape matches GitHub's spec (`version: 2`, empty `updates:` list)
- [x] `pnpm run lint` end-to-end passes (Biome + cspell + markdownlint)
- [ ] CI passes
- [ ] Post-merge: maintainer installs the Renovate App and merges the onboarding PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated dependency management configuration to streamline automated update handling and improve maintainability through refined scheduling and grouping rules for dependency updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->