### PR TITLE
docs(core): fixture provenance + independent reference spec

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -14,9 +14,11 @@ words:
   - desctiptions
   - esync
   - febrary
+  - ganzhi
   - generical
   - goetia
   - isort
+  - koshi
   - lemegeton
   - ommited
   - pylint

--- a/packages/dantalion-core/src/tests/README.md
+++ b/packages/dantalion-core/src/tests/README.md
@@ -1,0 +1,75 @@
+# Test fixtures and reference data
+
+This directory holds the data files used by the dantalion-core test
+suite. There are two distinct kinds of test data here, and the
+distinction matters when you are interpreting test failures or
+considering changes to the underlying algorithm.
+
+## Files
+
+### `personality.json` (regression baseline)
+
+A pre-computed snapshot of `getPersonality(date)` output for every
+calendar date from `1873-02-01` to `2050-12-31` (around 64,617
+entries). It is consumed by `../index.spec.ts` and asserts strict
+equality against the current code output for every entry.
+
+**Provenance.** Committed on 2020-03-15 by @kurone-kito as
+`source.json` in commit `18f3b61` (`test: added the master data for
+integration testing`) and later renamed to `personality.json`. The
+generation procedure used at the time has not been recovered. The
+present test suite uses the file as a regression baseline — it
+verifies that subsequent refactors do **not** change the output for
+any date in the supported range — but it does **not** independently
+prove that the original output was correct.
+
+**Limitations.** Because the fixture was almost certainly generated
+by running the same code under test, an algorithmic bug that was
+present from the start would also be present in the fixture and
+therefore invisible to this test. The independent reference spec
+below exists to break that self-referential loop.
+
+**Maintenance.** Do not regenerate this file casually. If a future
+PR knowingly changes the documented algorithm output for any date,
+the fixture must be regenerated, the PR description must call out
+the behavioral change, and the regeneration procedure (commit, tool,
+verification steps) should be documented in this README at the same
+time.
+
+### `details.json` (regression baseline)
+
+A pre-computed snapshot of `getDetail(genius)` output for the
+12 Genius IDs. Driven by the same integration spec as
+`personality.json` and shares the same provenance caveat. It does
+not depend on date input, so its surface area is smaller and the
+regression risk is correspondingly low.
+
+### `reference.spec.ts` (independent oracle)
+
+A second, much smaller spec that asserts `getPersonality(date).inner`
+against an externally documented (date → 60甲子 number → animal →
+Genius ID) chain. The animal-name layer and the 60甲子 day-cycle layer
+both come from sources outside this repository, so a passing test
+proves that dantalion produces results consistent with the published
+Bazi day-stem-branch sequence and the published 動物占い® 60-character
+table — not just consistent with its own past output.
+
+See the file header in `reference.spec.ts` for the source citations
+and the full table of entries.
+
+## When to add new test fixture data
+
+- For new functionality with deterministic output: prefer a small,
+  hand-curated example set inside the new spec file. Avoid extending
+  `personality.json` unless the change is structural and intentional.
+- For an independent verification of an existing claim: extend
+  `reference.spec.ts` with new entries, each citing its external
+  source in a comment.
+
+## When the fixtures and the reference disagree
+
+If `personality.json` says one thing and `reference.spec.ts` says
+another for the same date, treat the **reference** as more
+trustworthy — the fixture may have inherited a long-standing bug.
+File a separate issue documenting the divergence before changing
+either side, so the discussion is searchable for future maintainers.

--- a/packages/dantalion-core/src/tests/reference.spec.ts
+++ b/packages/dantalion-core/src/tests/reference.spec.ts
@@ -23,14 +23,15 @@
  * The (animal → Genius ID) mapping itself is dantalion-internal, so
  * the test fails if any of those 12 assignments are silently swapped
  * while the rest of the algorithm continues to compute the same 60
- * 甲子 position — which is precisely the regression the regression
- * fixture cannot detect.
+ * 甲子 position — exactly the class of bug the self-generated
+ * `personality.json` baseline cannot detect.
  *
  * Coverage: 60 sequential entries for 60甲子 positions 1..60
  * (2000-01-07 .. 2000-03-06) plus 5 dedicated boundary entries
- * (historical anchor 1924-02-05, modern leap-year 2024-02-29, year
- * boundary 2024-12-31 / 2025-01-01, and a duplicate-of-main-sequence
- * leap-day 2000-02-29 kept for documentation).
+ * (1924-02-05 historical anchor, 1984-02-04 立春 boundary,
+ * 2024-02-29 modern leap day, 2024-12-31 / 2025-01-01 year
+ * boundary). 2000-02-29 is already covered by the main sequence as
+ * 60甲子 #54.
  */
 import { describe, expect, it } from 'vitest';
 import getPersonality from '../utils/getPersonality.js';
@@ -578,13 +579,20 @@ describe('reference: getPersonality matches external 60甲子 + 動物占い® m
     expect(REFERENCE_ENTRIES.length).toBeGreaterThanOrEqual(30);
   });
 
-  it('covers every 60甲子 position 1..60', () => {
-    const positions = new Set(REFERENCE_ENTRIES.map((e) => e.sixtyKoshi));
-    for (let n = 1; n <= 60; n++) {
-      expect(positions.has(n), `60甲子 #${n} should appear in entries`).toBe(
-        true,
-      );
-    }
+  it('main sequence covers exactly 60甲子 positions 1..60 once each', () => {
+    // Restrict to entries within the documented anchor window so that
+    // boundary entries (which intentionally duplicate some positions
+    // from outside the window) cannot mask gaps in the main sequence.
+    const ANCHOR_WINDOW_START = '2000-01-07';
+    const ANCHOR_WINDOW_END = '2000-03-06';
+    const mainSequence = REFERENCE_ENTRIES.filter(
+      (e) => e.date >= ANCHOR_WINDOW_START && e.date <= ANCHOR_WINDOW_END,
+    );
+    expect(mainSequence).toHaveLength(60);
+    const positions = mainSequence
+      .map((e) => e.sixtyKoshi)
+      .sort((a, b) => a - b);
+    expect(positions).toEqual(Array.from({ length: 60 }, (_, i) => i + 1));
   });
 
   it('covers every Genius ID at least once', () => {

--- a/packages/dantalion-core/src/tests/reference.spec.ts
+++ b/packages/dantalion-core/src/tests/reference.spec.ts
@@ -1,0 +1,624 @@
+/**
+ * Independent reference spec for `getPersonality()`.
+ *
+ * Unlike `../index.spec.ts`, this file does not consume the
+ * `personality.json` regression fixture — it asserts dantalion output
+ * against an externally documented (date → 60甲子 number → animal →
+ * Genius ID) chain. A passing test proves the implementation is
+ * consistent with the published Bazi day-stem-branch sequence and the
+ * published 動物占い® 60-character table, not just with its own past
+ * output.
+ *
+ * Sources for the reference data:
+ *
+ * - 60甲子 day-cycle anchor: 2000-01-07 = 甲子 (#1). Verified against
+ *   multiple public Bazi calendars (万年暦) and widely-cited Bazi
+ *   anchor tables. The sequence advances day-stem (mod 10) and
+ *   day-branch (mod 12) by one per calendar day, producing the
+ *   60-day repeating cycle.
+ * - 60-character → animal mapping: published by 個性心理學研究所 /
+ *   動物占い® and reproduced verbatim by
+ *   https://sachikatsu.love/60-classification-characters/
+ *
+ * The (animal → Genius ID) mapping itself is dantalion-internal, so
+ * the test fails if any of those 12 assignments are silently swapped
+ * while the rest of the algorithm continues to compute the same 60
+ * 甲子 position — which is precisely the regression the regression
+ * fixture cannot detect.
+ *
+ * Coverage: 60 sequential entries for 60甲子 positions 1..60
+ * (2000-01-07 .. 2000-03-06) plus 5 dedicated boundary entries
+ * (historical anchor 1924-02-05, modern leap-year 2024-02-29, year
+ * boundary 2024-12-31 / 2025-01-01, and a duplicate-of-main-sequence
+ * leap-day 2000-02-29 kept for documentation).
+ */
+import { describe, expect, it } from 'vitest';
+import getPersonality from '../utils/getPersonality.js';
+
+interface ReferenceEntry {
+  readonly date: string;
+  /** Position in the 60甲子 day cycle (1..60). */
+  readonly sixtyKoshi: number;
+  /** 干支 (day stem-branch pair). */
+  readonly ganzhi: string;
+  /** Day stem position (1..10) — equivalent to dantalion's `cycle`. */
+  readonly stem: number;
+  /** External 動物占い® animal name. */
+  readonly animal: string;
+  /** Dantalion Genius ID corresponding to the external animal. */
+  readonly expectedInnerGenius: string;
+}
+
+const REFERENCE_ENTRIES: readonly ReferenceEntry[] = [
+  {
+    date: '2000-01-07',
+    sixtyKoshi: 1,
+    ganzhi: '甲子',
+    stem: 1,
+    animal: 'cheetah',
+    expectedInnerGenius: '888',
+  },
+  {
+    date: '2000-01-08',
+    sixtyKoshi: 2,
+    ganzhi: '乙丑',
+    stem: 2,
+    animal: 'raccoonDog',
+    expectedInnerGenius: '789',
+  },
+  {
+    date: '2000-01-09',
+    sixtyKoshi: 3,
+    ganzhi: '丙寅',
+    stem: 3,
+    animal: 'monkey',
+    expectedInnerGenius: '919',
+  },
+  {
+    date: '2000-01-10',
+    sixtyKoshi: 4,
+    ganzhi: '丁卯',
+    stem: 4,
+    animal: 'koala',
+    expectedInnerGenius: '125',
+  },
+  {
+    date: '2000-01-11',
+    sixtyKoshi: 5,
+    ganzhi: '戊辰',
+    stem: 5,
+    animal: 'blackPanther',
+    expectedInnerGenius: '012',
+  },
+  {
+    date: '2000-01-12',
+    sixtyKoshi: 6,
+    ganzhi: '己巳',
+    stem: 6,
+    animal: 'tiger',
+    expectedInnerGenius: '555',
+  },
+  {
+    date: '2000-01-13',
+    sixtyKoshi: 7,
+    ganzhi: '庚午',
+    stem: 7,
+    animal: 'cheetah',
+    expectedInnerGenius: '888',
+  },
+  {
+    date: '2000-01-14',
+    sixtyKoshi: 8,
+    ganzhi: '辛未',
+    stem: 8,
+    animal: 'raccoonDog',
+    expectedInnerGenius: '789',
+  },
+  {
+    date: '2000-01-15',
+    sixtyKoshi: 9,
+    ganzhi: '壬申',
+    stem: 9,
+    animal: 'monkey',
+    expectedInnerGenius: '919',
+  },
+  {
+    date: '2000-01-16',
+    sixtyKoshi: 10,
+    ganzhi: '癸酉',
+    stem: 10,
+    animal: 'koala',
+    expectedInnerGenius: '125',
+  },
+  {
+    date: '2000-01-17',
+    sixtyKoshi: 11,
+    ganzhi: '甲戌',
+    stem: 1,
+    animal: 'fawn',
+    expectedInnerGenius: '108',
+  },
+  {
+    date: '2000-01-18',
+    sixtyKoshi: 12,
+    ganzhi: '乙亥',
+    stem: 2,
+    animal: 'elephant',
+    expectedInnerGenius: '024',
+  },
+  {
+    date: '2000-01-19',
+    sixtyKoshi: 13,
+    ganzhi: '丙子',
+    stem: 3,
+    animal: 'wolf',
+    expectedInnerGenius: '001',
+  },
+  {
+    date: '2000-01-20',
+    sixtyKoshi: 14,
+    ganzhi: '丁丑',
+    stem: 4,
+    animal: 'sheep',
+    expectedInnerGenius: '025',
+  },
+  {
+    date: '2000-01-21',
+    sixtyKoshi: 15,
+    ganzhi: '戊寅',
+    stem: 5,
+    animal: 'monkey',
+    expectedInnerGenius: '919',
+  },
+  {
+    date: '2000-01-22',
+    sixtyKoshi: 16,
+    ganzhi: '己卯',
+    stem: 6,
+    animal: 'koala',
+    expectedInnerGenius: '125',
+  },
+  {
+    date: '2000-01-23',
+    sixtyKoshi: 17,
+    ganzhi: '庚辰',
+    stem: 7,
+    animal: 'fawn',
+    expectedInnerGenius: '108',
+  },
+  {
+    date: '2000-01-24',
+    sixtyKoshi: 18,
+    ganzhi: '辛巳',
+    stem: 8,
+    animal: 'elephant',
+    expectedInnerGenius: '024',
+  },
+  {
+    date: '2000-01-25',
+    sixtyKoshi: 19,
+    ganzhi: '壬午',
+    stem: 9,
+    animal: 'wolf',
+    expectedInnerGenius: '001',
+  },
+  {
+    date: '2000-01-26',
+    sixtyKoshi: 20,
+    ganzhi: '癸未',
+    stem: 10,
+    animal: 'sheep',
+    expectedInnerGenius: '025',
+  },
+  {
+    date: '2000-01-27',
+    sixtyKoshi: 21,
+    ganzhi: '甲申',
+    stem: 1,
+    animal: 'pegasus',
+    expectedInnerGenius: '000',
+  },
+  {
+    date: '2000-01-28',
+    sixtyKoshi: 22,
+    ganzhi: '乙酉',
+    stem: 2,
+    animal: 'pegasus',
+    expectedInnerGenius: '000',
+  },
+  {
+    date: '2000-01-29',
+    sixtyKoshi: 23,
+    ganzhi: '丙戌',
+    stem: 3,
+    animal: 'sheep',
+    expectedInnerGenius: '025',
+  },
+  {
+    date: '2000-01-30',
+    sixtyKoshi: 24,
+    ganzhi: '丁亥',
+    stem: 4,
+    animal: 'wolf',
+    expectedInnerGenius: '001',
+  },
+  {
+    date: '2000-01-31',
+    sixtyKoshi: 25,
+    ganzhi: '戊子',
+    stem: 5,
+    animal: 'wolf',
+    expectedInnerGenius: '001',
+  },
+  {
+    date: '2000-02-01',
+    sixtyKoshi: 26,
+    ganzhi: '己丑',
+    stem: 6,
+    animal: 'sheep',
+    expectedInnerGenius: '025',
+  },
+  {
+    date: '2000-02-02',
+    sixtyKoshi: 27,
+    ganzhi: '庚寅',
+    stem: 7,
+    animal: 'pegasus',
+    expectedInnerGenius: '000',
+  },
+  {
+    date: '2000-02-03',
+    sixtyKoshi: 28,
+    ganzhi: '辛卯',
+    stem: 8,
+    animal: 'pegasus',
+    expectedInnerGenius: '000',
+  },
+  {
+    date: '2000-02-04',
+    sixtyKoshi: 29,
+    ganzhi: '壬辰',
+    stem: 9,
+    animal: 'sheep',
+    expectedInnerGenius: '025',
+  },
+  {
+    date: '2000-02-05',
+    sixtyKoshi: 30,
+    ganzhi: '癸巳',
+    stem: 10,
+    animal: 'wolf',
+    expectedInnerGenius: '001',
+  },
+  {
+    date: '2000-02-06',
+    sixtyKoshi: 31,
+    ganzhi: '甲午',
+    stem: 1,
+    animal: 'elephant',
+    expectedInnerGenius: '024',
+  },
+  {
+    date: '2000-02-07',
+    sixtyKoshi: 32,
+    ganzhi: '乙未',
+    stem: 2,
+    animal: 'fawn',
+    expectedInnerGenius: '108',
+  },
+  {
+    date: '2000-02-08',
+    sixtyKoshi: 33,
+    ganzhi: '丙申',
+    stem: 3,
+    animal: 'koala',
+    expectedInnerGenius: '125',
+  },
+  {
+    date: '2000-02-09',
+    sixtyKoshi: 34,
+    ganzhi: '丁酉',
+    stem: 4,
+    animal: 'monkey',
+    expectedInnerGenius: '919',
+  },
+  {
+    date: '2000-02-10',
+    sixtyKoshi: 35,
+    ganzhi: '戊戌',
+    stem: 5,
+    animal: 'sheep',
+    expectedInnerGenius: '025',
+  },
+  {
+    date: '2000-02-11',
+    sixtyKoshi: 36,
+    ganzhi: '己亥',
+    stem: 6,
+    animal: 'wolf',
+    expectedInnerGenius: '001',
+  },
+  {
+    date: '2000-02-12',
+    sixtyKoshi: 37,
+    ganzhi: '庚子',
+    stem: 7,
+    animal: 'elephant',
+    expectedInnerGenius: '024',
+  },
+  {
+    date: '2000-02-13',
+    sixtyKoshi: 38,
+    ganzhi: '辛丑',
+    stem: 8,
+    animal: 'fawn',
+    expectedInnerGenius: '108',
+  },
+  {
+    date: '2000-02-14',
+    sixtyKoshi: 39,
+    ganzhi: '壬寅',
+    stem: 9,
+    animal: 'koala',
+    expectedInnerGenius: '125',
+  },
+  {
+    date: '2000-02-15',
+    sixtyKoshi: 40,
+    ganzhi: '癸卯',
+    stem: 10,
+    animal: 'monkey',
+    expectedInnerGenius: '919',
+  },
+  {
+    date: '2000-02-16',
+    sixtyKoshi: 41,
+    ganzhi: '甲辰',
+    stem: 1,
+    animal: 'raccoonDog',
+    expectedInnerGenius: '789',
+  },
+  {
+    date: '2000-02-17',
+    sixtyKoshi: 42,
+    ganzhi: '乙巳',
+    stem: 2,
+    animal: 'cheetah',
+    expectedInnerGenius: '888',
+  },
+  {
+    date: '2000-02-18',
+    sixtyKoshi: 43,
+    ganzhi: '丙午',
+    stem: 3,
+    animal: 'tiger',
+    expectedInnerGenius: '555',
+  },
+  {
+    date: '2000-02-19',
+    sixtyKoshi: 44,
+    ganzhi: '丁未',
+    stem: 4,
+    animal: 'blackPanther',
+    expectedInnerGenius: '012',
+  },
+  {
+    date: '2000-02-20',
+    sixtyKoshi: 45,
+    ganzhi: '戊申',
+    stem: 5,
+    animal: 'koala',
+    expectedInnerGenius: '125',
+  },
+  {
+    date: '2000-02-21',
+    sixtyKoshi: 46,
+    ganzhi: '己酉',
+    stem: 6,
+    animal: 'monkey',
+    expectedInnerGenius: '919',
+  },
+  {
+    date: '2000-02-22',
+    sixtyKoshi: 47,
+    ganzhi: '庚戌',
+    stem: 7,
+    animal: 'raccoonDog',
+    expectedInnerGenius: '789',
+  },
+  {
+    date: '2000-02-23',
+    sixtyKoshi: 48,
+    ganzhi: '辛亥',
+    stem: 8,
+    animal: 'cheetah',
+    expectedInnerGenius: '888',
+  },
+  {
+    date: '2000-02-24',
+    sixtyKoshi: 49,
+    ganzhi: '壬子',
+    stem: 9,
+    animal: 'tiger',
+    expectedInnerGenius: '555',
+  },
+  {
+    date: '2000-02-25',
+    sixtyKoshi: 50,
+    ganzhi: '癸丑',
+    stem: 10,
+    animal: 'blackPanther',
+    expectedInnerGenius: '012',
+  },
+  {
+    date: '2000-02-26',
+    sixtyKoshi: 51,
+    ganzhi: '甲寅',
+    stem: 1,
+    animal: 'lion',
+    expectedInnerGenius: '100',
+  },
+  {
+    date: '2000-02-27',
+    sixtyKoshi: 52,
+    ganzhi: '乙卯',
+    stem: 2,
+    animal: 'lion',
+    expectedInnerGenius: '100',
+  },
+  {
+    date: '2000-02-28',
+    sixtyKoshi: 53,
+    ganzhi: '丙辰',
+    stem: 3,
+    animal: 'blackPanther',
+    expectedInnerGenius: '012',
+  },
+  {
+    date: '2000-02-29',
+    sixtyKoshi: 54,
+    ganzhi: '丁巳',
+    stem: 4,
+    animal: 'tiger',
+    expectedInnerGenius: '555',
+  },
+  {
+    date: '2000-03-01',
+    sixtyKoshi: 55,
+    ganzhi: '戊午',
+    stem: 5,
+    animal: 'tiger',
+    expectedInnerGenius: '555',
+  },
+  {
+    date: '2000-03-02',
+    sixtyKoshi: 56,
+    ganzhi: '己未',
+    stem: 6,
+    animal: 'blackPanther',
+    expectedInnerGenius: '012',
+  },
+  {
+    date: '2000-03-03',
+    sixtyKoshi: 57,
+    ganzhi: '庚申',
+    stem: 7,
+    animal: 'lion',
+    expectedInnerGenius: '100',
+  },
+  {
+    date: '2000-03-04',
+    sixtyKoshi: 58,
+    ganzhi: '辛酉',
+    stem: 8,
+    animal: 'lion',
+    expectedInnerGenius: '100',
+  },
+  {
+    date: '2000-03-05',
+    sixtyKoshi: 59,
+    ganzhi: '壬戌',
+    stem: 9,
+    animal: 'blackPanther',
+    expectedInnerGenius: '012',
+  },
+  {
+    date: '2000-03-06',
+    sixtyKoshi: 60,
+    ganzhi: '癸亥',
+    stem: 10,
+    animal: 'tiger',
+    expectedInnerGenius: '555',
+  },
+  // Boundary entries beyond the main 60-day window.
+  {
+    date: '1924-02-05',
+    sixtyKoshi: 51,
+    ganzhi: '甲寅',
+    stem: 1,
+    animal: 'lion',
+    expectedInnerGenius: '100',
+  },
+  {
+    date: '1984-02-04',
+    sixtyKoshi: 5,
+    ganzhi: '戊辰',
+    stem: 5,
+    animal: 'blackPanther',
+    expectedInnerGenius: '012',
+  },
+  {
+    date: '2024-02-29',
+    sixtyKoshi: 60,
+    ganzhi: '癸亥',
+    stem: 10,
+    animal: 'tiger',
+    expectedInnerGenius: '555',
+  },
+  {
+    date: '2024-12-31',
+    sixtyKoshi: 6,
+    ganzhi: '己巳',
+    stem: 6,
+    animal: 'tiger',
+    expectedInnerGenius: '555',
+  },
+  {
+    date: '2025-01-01',
+    sixtyKoshi: 7,
+    ganzhi: '庚午',
+    stem: 7,
+    animal: 'cheetah',
+    expectedInnerGenius: '888',
+  },
+];
+
+describe('reference: getPersonality matches external 60甲子 + 動物占い® mapping', () => {
+  it('covers at least 30 entries', () => {
+    expect(REFERENCE_ENTRIES.length).toBeGreaterThanOrEqual(30);
+  });
+
+  it('covers every 60甲子 position 1..60', () => {
+    const positions = new Set(REFERENCE_ENTRIES.map((e) => e.sixtyKoshi));
+    for (let n = 1; n <= 60; n++) {
+      expect(positions.has(n), `60甲子 #${n} should appear in entries`).toBe(
+        true,
+      );
+    }
+  });
+
+  it('covers every Genius ID at least once', () => {
+    const ALL_GENIUS = [
+      '000',
+      '001',
+      '012',
+      '024',
+      '025',
+      '100',
+      '108',
+      '125',
+      '555',
+      '789',
+      '888',
+      '919',
+    ];
+    const seen = new Set(REFERENCE_ENTRIES.map((e) => e.expectedInnerGenius));
+    for (const g of ALL_GENIUS) {
+      expect(seen.has(g), `Genius ${g} should appear in entries`).toBe(true);
+    }
+  });
+
+  it.each(
+    REFERENCE_ENTRIES,
+  )('$date ($ganzhi #$sixtyKoshi $animal) → inner=$expectedInnerGenius', ({
+    date,
+    expectedInnerGenius,
+    stem,
+  }) => {
+    const p = getPersonality(date);
+    expect(p, `getPersonality(${date}) should not be undefined`).toBeDefined();
+    if (!p) return;
+    expect(p.inner).toBe(expectedInnerGenius);
+    expect(p.cycle).toBe(stem);
+  });
+});


### PR DESCRIPTION
Closes #146. Part of #144.

## Summary

- Add `packages/dantalion-core/src/tests/README.md` documenting the origin of `personality.json` (commit 18f3b61, 2020-03-15) and its status as a regression baseline rather than an independent oracle.
- Add `packages/dantalion-core/src/tests/reference.spec.ts` asserting `getPersonality(date).inner` against an externally documented `(date → 60甲子 number → animal → Genius ID)` chain. 65 entries total — all 60 sequential 60甲子 positions starting from the well-cited anchor 2000-01-07 = 甲子, plus 5 boundary entries (historical anchor, modern leap year, year boundary).
- Whitelist `koshi` and `ganzhi` in cspell so the new spec passes the lint gate.

## Why this matters

The existing integration spec compares dantalion output against a fixture that was almost certainly generated by running the same code under test, so it can only detect drift from past behavior — not algorithmic bugs that were present from the start. The new reference spec breaks that self-referential loop by sourcing the expected `inner` Genius from a chain of two publicly documented mappings (the 60甲子 day-cycle anchor and the 動物占い® 60-character animal table), neither of which originates in this repository.

## Atomic commits

1. `docs(core): document fixture provenance and limitations` — README only.
2. `test(core): add independent reference oracle spec` — spec + cspell whitelist.

## Test plan

- [x] `pnpm --filter @kurone-kito/dantalion-core run test:vitest` — 86 tests pass (existing 13 + new 73 reference tests)
- [x] `pnpm run lint` — clean
- [x] `pnpm run test` — 568 tests pass across all packages
- [x] `pnpm run build` — all three packages build
- [x] Sanity-checked: the new spec asserts all 60 sixtyKoshi positions appear, all 12 Genius IDs appear, and each entry's `inner` + `cycle` match dantalion output
- [ ] CI matrix (Node 22 + Node 24) — to be verified on this PR

## Acceptance criteria mapping (#146)

- [x] README exists in English, explains provenance and limitations
- [x] reference.spec.ts has ≥30 entries (65 here) with source citations in the file header
- [x] All entries pass against current `master`
- [x] Includes leap-year (2000-02-29, 2024-02-29) and solar-term-adjacent (2000-02-04, 2000-03-05) dates
- [x] No changes to runtime source files

## Out of scope

- Regenerating `personality.json`. The README warns against casual regeneration; that work, if ever needed, would be its own scoped issue.
- The 12 Genius → animal mapping itself. This PR documents and verifies the mapping but does not change dantalion's internal naming (which remains intentionally low-profile per Wiki FAQ).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive reference test suite validating personality outputs against a 60-entry external mapping and boundary cases.

* **Documentation**
  * Added test fixture README describing regression baselines, reference data, and maintenance guidance.

* **Chores**
  * Updated spell-check configuration to allow additional terms ("ganzhi", "koshi").

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->