### PR TITLE
test(core): unit tests for util primitives + property tests

### DIFF
--- a/packages/dantalion-core/package.json
+++ b/packages/dantalion-core/package.json
@@ -48,5 +48,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "fast-check": "^4.8.0"
   }
 }

--- a/packages/dantalion-core/src/utils/assertDefined.spec.ts
+++ b/packages/dantalion-core/src/utils/assertDefined.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import assertDefined from './assertDefined.js';
+
+describe('assertDefined', () => {
+  it.each<[string, unknown]>([
+    ['string', 'value'],
+    ['empty string', ''],
+    ['number', 42],
+    ['zero', 0],
+    ['negative number', -1],
+    ['boolean true', true],
+    ['boolean false', false],
+    ['null', null],
+    ['object', { ok: true }],
+    ['empty array', []],
+    ['NaN', Number.NaN],
+  ])('returns the value unchanged for a defined %s', (_label, value) => {
+    expect(assertDefined(value)).toBe(value);
+  });
+
+  it('throws when value is undefined', () => {
+    expect(() => assertDefined(undefined)).toThrowError(
+      /assertDefined: value is undefined/,
+    );
+  });
+
+  it('throws with the caller-supplied message when provided', () => {
+    expect(() =>
+      assertDefined(undefined, 'custom invariant violation'),
+    ).toThrowError(/custom invariant violation/);
+  });
+
+  it('throws an Error instance (not a primitive)', () => {
+    try {
+      assertDefined(undefined);
+      expect.fail('assertDefined should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+    }
+  });
+
+  it('narrows the type so the result is non-nullable (compile-time check via runtime use)', () => {
+    const maybe: number | undefined = 5;
+    const definite: number = assertDefined(maybe);
+    // If this line type-checks at build time and runs at test time, the
+    // narrowing contract is honored. Vitest's `expect` does not exercise
+    // types directly; the build (tsc) is the contract enforcer here.
+    expect(definite).toBe(5);
+  });
+});

--- a/packages/dantalion-core/src/utils/create2DAccessor.spec.ts
+++ b/packages/dantalion-core/src/utils/create2DAccessor.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import create2DAccessor from './create2DAccessor.js';
+
+describe('create2DAccessor', () => {
+  const label = ['a', 'b', 'c'] as const;
+  const table: readonly number[][] = [
+    [0, 1, 2],
+    [2, 0, 1],
+    [1, 2, 0],
+  ];
+  const accessor = create2DAccessor({ label, table });
+
+  it.each<[number, number, string]>([
+    [0, 0, 'a'],
+    [1, 0, 'b'],
+    [2, 0, 'c'],
+    [0, 1, 'c'],
+    [1, 1, 'a'],
+    [2, 1, 'b'],
+    [0, 2, 'b'],
+    [1, 2, 'c'],
+    [2, 2, 'a'],
+  ])('({ x: %i, y: %i }) === "%s"', (x, y, expected) => {
+    expect(accessor({ x, y })).toBe(expected);
+  });
+
+  it('defaults x and y to 0 when omitted', () => {
+    expect(accessor({})).toBe('a');
+    expect(accessor({ x: 1 })).toBe('b');
+    expect(accessor({ y: 1 })).toBe('c');
+  });
+
+  it('throws via assertDefined when y is out of range', () => {
+    expect(() => accessor({ x: 0, y: 99 })).toThrowError(/assertDefined/);
+  });
+
+  it('throws via assertDefined when x is out of range', () => {
+    expect(() => accessor({ x: 99, y: 0 })).toThrowError(/assertDefined/);
+  });
+
+  it('throws via assertDefined when the resolved label index is out of range', () => {
+    const labelTooShort = ['a'] as const;
+    const tableWithHighIndex: readonly number[][] = [[5]];
+    const sparseAccessor = create2DAccessor({
+      label: labelTooShort,
+      table: tableWithHighIndex,
+    });
+    expect(() => sparseAccessor({ x: 0, y: 0 })).toThrowError(/assertDefined/);
+  });
+});

--- a/packages/dantalion-core/src/utils/getPersonality.property.spec.ts
+++ b/packages/dantalion-core/src/utils/getPersonality.property.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * Property-based tests for `getPersonality`. These complement the
+ * regression baseline (`personality.json` walk) and the independent
+ * reference (`reference.spec.ts`) by asserting the algebraic
+ * invariants directly, so they survive any fixture rebuild and any
+ * documentation-only refactor.
+ */
+import fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import getPersonality from './getPersonality.js';
+
+const VALID_GENIUS = new Set([
+  '000',
+  '001',
+  '012',
+  '024',
+  '025',
+  '100',
+  '108',
+  '125',
+  '555',
+  '789',
+  '888',
+  '919',
+]);
+const VALID_LIFEBASE = new Set([
+  'application',
+  'association',
+  'development',
+  'expression',
+  'finance',
+  'investment',
+  'organization',
+  'quest',
+  'selfMind',
+  'selfReliance',
+]);
+
+const inRangeDate = fc
+  .date({
+    min: new Date(Date.UTC(1873, 1, 1)),
+    max: new Date(Date.UTC(2050, 11, 31)),
+    noInvalidDate: true,
+  })
+  .map((d) => d.toISOString().slice(0, 10));
+
+const outOfRangeDate = fc.oneof(
+  fc
+    .date({
+      min: new Date(Date.UTC(1700, 0, 1)),
+      max: new Date(Date.UTC(1873, 0, 31)),
+      noInvalidDate: true,
+    })
+    .map((d) => d.toISOString().slice(0, 10)),
+  fc
+    .date({
+      min: new Date(Date.UTC(2051, 0, 1)),
+      max: new Date(Date.UTC(2200, 11, 31)),
+      noInvalidDate: true,
+    })
+    .map((d) => d.toISOString().slice(0, 10)),
+);
+
+const addDays = (iso: string, days: number): string => {
+  const t = new Date(`${iso}T00:00:00Z`).getTime() + days * 86_400_000;
+  return new Date(t).toISOString().slice(0, 10);
+};
+
+describe('getPersonality — algebraic invariants', () => {
+  it('A: cycle ∈ [1, 10] for any in-range date', () => {
+    fc.assert(
+      fc.property(inRangeDate, (date) => {
+        const p = getPersonality(date);
+        if (!p) return true; // out-of-range slipped through
+        return Number.isInteger(p.cycle) && p.cycle >= 1 && p.cycle <= 10;
+      }),
+    );
+  });
+
+  it('B: 10-day stem period — cycle repeats every 10 days', () => {
+    // `cycle` corresponds to the day stem (1..10). The day stem advances
+    // by one each calendar day modulo 10, so `cycle(d) === cycle(d+10)`
+    // must hold whenever both dates are in range.
+    //
+    // (Note: `inner` does NOT repeat every 60 days even though the day
+    // stem-branch pair does — the 十二運 mapping that produces `inner`
+    // also reads the Bazi month, which advances across solar terms.
+    // The narrower 10-day cycle test is the strongest invariant that
+    // does not depend on month-pillar position.)
+    const safeWindow = fc
+      .date({
+        min: new Date(Date.UTC(1900, 0, 1)),
+        max: new Date(Date.UTC(2020, 11, 31)),
+        noInvalidDate: true,
+      })
+      .map((d) => d.toISOString().slice(0, 10));
+    fc.assert(
+      fc.property(safeWindow, (date) => {
+        const a = getPersonality(date);
+        const b = getPersonality(addDays(date, 10));
+        if (!a || !b) return true;
+        return a.cycle === b.cycle;
+      }),
+    );
+  });
+
+  it('C: determinism — same input yields identical output', () => {
+    fc.assert(
+      fc.property(inRangeDate, (date) => {
+        const a = JSON.stringify(getPersonality(date));
+        const b = JSON.stringify(getPersonality(date));
+        return a === b;
+      }),
+    );
+  });
+
+  it('D: inner / outer / workStyle ∈ valid Genius set', () => {
+    fc.assert(
+      fc.property(inRangeDate, (date) => {
+        const p = getPersonality(date);
+        if (!p) return true;
+        return (
+          VALID_GENIUS.has(p.inner) &&
+          VALID_GENIUS.has(p.outer) &&
+          VALID_GENIUS.has(p.workStyle)
+        );
+      }),
+    );
+  });
+
+  it('E: lifeBase ∈ valid LifeBase set', () => {
+    fc.assert(
+      fc.property(inRangeDate, (date) => {
+        const p = getPersonality(date);
+        if (!p) return true;
+        return VALID_LIFEBASE.has(p.lifeBase);
+      }),
+    );
+  });
+
+  it('F: out-of-range dates return undefined', () => {
+    fc.assert(
+      fc.property(outOfRangeDate, (date) => getPersonality(date) === undefined),
+    );
+  });
+
+  it('manual sanity: a few hand-picked dates produce in-range cycle', () => {
+    // Quick smoke that the property-based generators are actually
+    // exercising the function (not silently returning early).
+    for (const d of ['1900-06-15', '2000-01-07', '2024-12-31']) {
+      const p = getPersonality(d);
+      expect(p).toBeDefined();
+      if (!p) continue;
+      expect(p.cycle).toBeGreaterThanOrEqual(1);
+      expect(p.cycle).toBeLessThanOrEqual(10);
+    }
+  });
+});

--- a/packages/dantalion-core/src/utils/getPersonality.property.spec.ts
+++ b/packages/dantalion-core/src/utils/getPersonality.property.spec.ts
@@ -71,7 +71,7 @@ describe('getPersonality — algebraic invariants', () => {
     fc.assert(
       fc.property(inRangeDate, (date) => {
         const p = getPersonality(date);
-        if (!p) return true; // out-of-range slipped through
+        if (!p) return false; // in-range generator must not yield undefined
         return Number.isInteger(p.cycle) && p.cycle >= 1 && p.cycle <= 10;
       }),
     );
@@ -98,7 +98,7 @@ describe('getPersonality — algebraic invariants', () => {
       fc.property(safeWindow, (date) => {
         const a = getPersonality(date);
         const b = getPersonality(addDays(date, 10));
-        if (!a || !b) return true;
+        if (!a || !b) return false; // both dates in safe window must resolve
         return a.cycle === b.cycle;
       }),
     );
@@ -118,7 +118,7 @@ describe('getPersonality — algebraic invariants', () => {
     fc.assert(
       fc.property(inRangeDate, (date) => {
         const p = getPersonality(date);
-        if (!p) return true;
+        if (!p) return false; // in-range generator must not yield undefined
         return (
           VALID_GENIUS.has(p.inner) &&
           VALID_GENIUS.has(p.outer) &&
@@ -132,7 +132,7 @@ describe('getPersonality — algebraic invariants', () => {
     fc.assert(
       fc.property(inRangeDate, (date) => {
         const p = getPersonality(date);
-        if (!p) return true;
+        if (!p) return false; // in-range generator must not yield undefined
         return VALID_LIFEBASE.has(p.lifeBase);
       }),
     );
@@ -141,6 +141,14 @@ describe('getPersonality — algebraic invariants', () => {
   it('F: out-of-range dates return undefined', () => {
     fc.assert(
       fc.property(outOfRangeDate, (date) => getPersonality(date) === undefined),
+    );
+  });
+
+  it('sanity: in-range generator never yields undefined', () => {
+    // Negative control: confirm the `if (!p) return false` guards in
+    // A/B/D/E are not silently failing on every shrunk input.
+    fc.assert(
+      fc.property(inRangeDate, (date) => getPersonality(date) !== undefined),
     );
   });
 

--- a/packages/dantalion-core/src/utils/shiftAndModulo.spec.ts
+++ b/packages/dantalion-core/src/utils/shiftAndModulo.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import shiftAndModulo from './shiftAndModulo.js';
+
+describe('shiftAndModulo', () => {
+  it.each<[number, number, number]>([
+    [1, 10, 1],
+    [2, 10, 2],
+    [9, 10, 9],
+    [10, 10, 10],
+    [11, 10, 1],
+    [12, 10, 2],
+    [21, 10, 1],
+  ])('shiftAndModulo(%i, %i) === %i (positive small)', (a, n, expected) => {
+    expect(shiftAndModulo(a, n)).toBe(expected);
+  });
+
+  it('produces a value in the half-open range (0, n] for any positive dividend', () => {
+    for (let a = 0; a <= 200; a++) {
+      const r = shiftAndModulo(a, 12);
+      expect(r).toBeGreaterThanOrEqual(1);
+      expect(r).toBeLessThanOrEqual(12);
+    }
+  });
+
+  it('always returns a positive value for negative dividends', () => {
+    for (let a = -50; a < 0; a++) {
+      const r = shiftAndModulo(a, 10);
+      expect(r).toBeGreaterThanOrEqual(1);
+      expect(r).toBeLessThanOrEqual(10);
+    }
+  });
+
+  it('returns 1 for any input when n === 1', () => {
+    for (let a = -10; a <= 10; a++) {
+      expect(shiftAndModulo(a, 1)).toBe(1);
+    }
+  });
+
+  it('handles large values without overflow surprises', () => {
+    expect(shiftAndModulo(1_000_000, 12)).toBeGreaterThanOrEqual(1);
+    expect(shiftAndModulo(1_000_000, 12)).toBeLessThanOrEqual(12);
+    expect(shiftAndModulo(1_000_001, 12)).toBe(
+      ((shiftAndModulo(1_000_000, 12) - 1 + 1) % 12) + 1,
+    );
+  });
+});

--- a/packages/dantalion-core/src/utils/shiftAndModulo.spec.ts
+++ b/packages/dantalion-core/src/utils/shiftAndModulo.spec.ts
@@ -14,7 +14,7 @@ describe('shiftAndModulo', () => {
     expect(shiftAndModulo(a, n)).toBe(expected);
   });
 
-  it('produces a value in the half-open range (0, n] for any positive dividend', () => {
+  it('produces a value in [1, n] for any non-negative dividend', () => {
     for (let a = 0; a <= 200; a++) {
       const r = shiftAndModulo(a, 12);
       expect(r).toBeGreaterThanOrEqual(1);

--- a/packages/dantalion-core/src/utils/toCC.spec.ts
+++ b/packages/dantalion-core/src/utils/toCC.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import type { Personality } from './getPersonality.js';
+import toCC from './toCC.js';
+
+const samplePersonality: Personality = {
+  cycle: 1,
+  inner: '888',
+  outer: '789',
+  workStyle: '125',
+  lifeBase: 'application',
+  potentials: ['Io', 'Ii'],
+};
+
+describe('toCC', () => {
+  it('matches the documented CC format <inner>-<outer>-<workStyle>-<inner><c1>-<lifeBaseCC>-<potentialCC>-<potentialCC>', () => {
+    const cc = toCC(samplePersonality);
+    expect(cc).toMatch(/^\d{3}-\d{3}-\d{3}-\d{3}\d-[A-Z]-[a-z]-[a-z]$/);
+  });
+
+  it('encodes inner concatenated with cycle % 10 in the 4th segment', () => {
+    const cc = toCC({ ...samplePersonality, cycle: 1 });
+    expect(cc.split('-')[3]).toBe('8881');
+  });
+
+  it('uses 0 as the suffix when cycle is 10 (cycle % 10 wraps)', () => {
+    const cc = toCC({ ...samplePersonality, cycle: 10 });
+    expect(cc.split('-')[3]).toBe('8880');
+  });
+
+  it.each<[number, string]>([
+    [1, '1'],
+    [2, '2'],
+    [5, '5'],
+    [9, '9'],
+    [10, '0'],
+  ])('cycle %i → CC 4th-segment suffix "%s"', (cycle, suffix) => {
+    const cc = toCC({ ...samplePersonality, cycle });
+    const seg = cc.split('-')[3];
+    expect(seg).toBeDefined();
+    expect(seg).toBe(`888${suffix}`);
+  });
+
+  it('reverses potentials via reduceRight (potentialCC["Io"]="a", potentialCC["Ii"]="b", reversed → "-b-a" suffix)', () => {
+    const cc = toCC({ ...samplePersonality, potentials: ['Io', 'Ii'] });
+    // reduceRight visits the last element first, so for ['Io', 'Ii']
+    // the suffix is `-${cc[Ii]}-${cc[Io]}` = `-b-a`.
+    expect(cc.endsWith('-b-a')).toBe(true);
+  });
+
+  it('emits inner / outer / workStyle in their declared order', () => {
+    const cc = toCC(samplePersonality);
+    const [a, b, c] = cc.split('-');
+    expect(a).toBe(samplePersonality.inner);
+    expect(b).toBe(samplePersonality.outer);
+    expect(c).toBe(samplePersonality.workStyle);
+  });
+
+  it('embeds the single-letter lifeBaseCC token in the 5th segment', () => {
+    const cc = toCC(samplePersonality);
+    const seg = cc.split('-')[4];
+    expect(seg).toBeDefined();
+    expect(seg).toMatch(/^[A-Z]$/);
+    // application maps to 'G' per types/lifeBase.ts.
+    expect(seg).toBe('G');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,7 +111,11 @@ importers:
         specifier: ^9.6.1
         version: 9.6.1
 
-  packages/dantalion-core: {}
+  packages/dantalion-core:
+    devDependencies:
+      fast-check:
+        specifier: ^4.8.0
+        version: 4.8.0
 
   packages/dantalion-i18n:
     dependencies:
@@ -1198,6 +1202,10 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1770,6 +1778,9 @@ packages:
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -3167,6 +3178,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-equals@6.0.0: {}
@@ -3792,6 +3807,8 @@ snapshots:
       parse-ms: 4.0.0
 
   punycode.js@2.3.1: {}
+
+  pure-rand@8.4.0: {}
 
   queue-microtask@1.2.3: {}
 


### PR DESCRIPTION
Closes #147. Closes #148. Part of #144.

## Summary

Two atomic commits land the core-package test layer:

1. **`test(core): add unit tests for util primitives and toCC format`** — co-located specs for `shiftAndModulo`, `assertDefined`, `create2DAccessor`, and `toCC`. Locks down the documented CC string layout structurally (no snapshots).
2. **`test(core): add fast-check property tests for getPersonality`** — six algebraic invariants (cycle range, 10-day stem period, determinism, Genius/LifeBase set membership, out-of-range handling).

## Coverage impact

| | Before | After |
|---|---:|---:|
| `dantalion-core` statements | 98.4% | **100.0%** |
| `dantalion-core` branches   | 81.8% | **95.1%** |
| `dantalion-core` functions  | 100%  | 100% |

## Notable invariant discovery

While calibrating Property B, the broader claim that "60-day day-stem-branch cycle implies 60-day periodicity of `inner`" was disproved by fast-check (counterexample: 1900-02-28). The cause: the 十二運星 mapping that produces `inner` reads the Bazi month pillar, which advances at solar terms — so `inner` does not have 60-day periodicity. The narrower 10-day `cycle` periodicity does hold and is what the test now asserts. The header comment in the spec file documents this distinction so future readers do not re-attempt the broader claim.

## Test plan

- [x] `pnpm --filter @kurone-kito/dantalion-core run test:vitest` — 143 tests pass (up from 86)
- [x] `pnpm run test` — 625 tests pass across all packages (up from 568)
- [x] `pnpm run lint` — clean
- [x] `pnpm run build` — all three packages build
- [x] Coverage: branches 81.8% → 95.1% on dantalion-core, statements 98.4% → 100%
- [ ] CI matrix (Node 22 + Node 24) — to be verified on this PR

## Out of scope

- A separate spec file for `getFactors.ts` — the property tests transitively exercise it, and a dedicated spec would mostly restate the same invariants.
- Coverage thresholds — those are #150's scope and are intentionally landed later so this PR can raise the baseline first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a development dependency to enable property-based testing and strengthen test tooling.

* **Tests**
  * Added comprehensive test suites for core utilities: validation, 2D accessor behavior and defaults, date-based logic, shift/modulo math, and output encoding. Tests cover unit cases, edge conditions, error handling, determinism, and property-based invariants for range correctness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->