### PR TITLE
ci: per-package vitest coverage thresholds (lock in baseline)

### DIFF
--- a/packages/dantalion-cli/vitest.config.mts
+++ b/packages/dantalion-cli/vitest.config.mts
@@ -8,6 +8,20 @@ export default defineConfig({
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.spec.ts'],
+      // The CLI smoke spec (#145) invokes the built `dist/src/index.js`
+      // through `execa`, so v8 instrumentation cannot follow the
+      // subprocess and reports 0% coverage here. Setting any positive
+      // threshold would fail CI immediately. The thresholds remain
+      // declared (as the project standard) at 0, and an in-process
+      // CLI matrix that would produce real coverage numbers is
+      // intentionally tracked separately in #152.
+      // Baseline measured 2026-05-20.
+      thresholds: {
+        statements: 0,
+        branches: 0,
+        functions: 0,
+        lines: 0,
+      },
     },
   },
 });

--- a/packages/dantalion-core/vitest.config.mts
+++ b/packages/dantalion-core/vitest.config.mts
@@ -14,7 +14,7 @@ export default defineConfig({
       // churn while catching real regressions.
       thresholds: {
         statements: 98,
-        branches: 90,
+        branches: 91,
         functions: 98,
         lines: 98,
       },

--- a/packages/dantalion-core/vitest.config.mts
+++ b/packages/dantalion-core/vitest.config.mts
@@ -8,6 +8,16 @@ export default defineConfig({
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.spec.ts', 'src/tests/**'],
+      // Baseline measured 2026-05-20 after #145–#149 landed:
+      // stmt 100%, branch 95.4%, func 100%, lines 100%.
+      // Thresholds set 2–5 pp below baseline to allow modest refactor
+      // churn while catching real regressions.
+      thresholds: {
+        statements: 98,
+        branches: 90,
+        functions: 98,
+        lines: 98,
+      },
     },
   },
 });

--- a/packages/dantalion-i18n/vitest.config.mts
+++ b/packages/dantalion-i18n/vitest.config.mts
@@ -8,6 +8,16 @@ export default defineConfig({
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.spec.ts'],
+      // Baseline measured 2026-05-20 after #149 landed:
+      // stmt 100%, branch 95.2%, func 100%, lines 100%.
+      // Thresholds set 2–5 pp below baseline to allow modest refactor
+      // churn while catching real regressions.
+      thresholds: {
+        statements: 98,
+        branches: 90,
+        functions: 98,
+        lines: 98,
+      },
     },
   },
 });

--- a/packages/dantalion-i18n/vitest.config.mts
+++ b/packages/dantalion-i18n/vitest.config.mts
@@ -14,7 +14,7 @@ export default defineConfig({
       // churn while catching real regressions.
       thresholds: {
         statements: 98,
-        branches: 90,
+        branches: 91,
         functions: 98,
         lines: 98,
       },


### PR DESCRIPTION
Closes #150. Part of #144.

## Summary

Lock in the coverage baseline that the prior test-quality PRs (#145–#149) raised. Each `packages/*/vitest.config.mts` now declares `coverage.thresholds`.

| Package          | Threshold | Baseline (2026-05-20) |
|------------------|-----------|------------------------|
| `dantalion-core` | stmt 98 / branch 90 / func 98 / lines 98 | 100 / 95.45 / 100 / 100 |
| `dantalion-i18n` | stmt 98 / branch 90 / func 98 / lines 98 | 100 / 95.24 / 100 / 100 |
| `dantalion-cli`  | stmt 0 / branch 0 / func 0 / lines 0     | 0 / 0 / 0 / 0          |

`dantalion-cli` thresholds are 0 because the smoke spec invokes the CLI via `execa` and v8 instrumentation cannot follow into the subprocess. The block is still declared (project standard); a real CLI matrix that produces in-process coverage is tracked by #152.

## Sanity check

Verified locally:

- Bumping `dantalion-core` branch threshold to 99 → CI fails with `Coverage for branches (95.45%) does not meet global threshold (99%)`.
- Restoring to 90 → CI passes.

## Test plan

- [x] `pnpm run test` passes with the new thresholds (642 tests, all green)
- [x] `pnpm run lint` clean
- [x] Negative sanity verified (see above)
- [ ] CI matrix (Node 22 + 24) — to be verified on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured code coverage thresholds across test configurations to enforce minimum quality standards. Established baseline coverage requirements for multiple packages to maintain consistent code quality and prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->