### PR TITLE
test(cli): full command × flag matrix + in-process unit specs

### DIFF
--- a/packages/dantalion-cli/src/detail.spec.ts
+++ b/packages/dantalion-cli/src/detail.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import command from './detail.js';
+
+describe('detail command (in-process)', () => {
+  describe('command metadata', () => {
+    it('declares the expected commander wiring', () => {
+      expect(command.command).toBe('detail [genius]');
+      expect(command.alias).toBe('dt');
+      expect(command.description).toEqual(expect.any(String));
+      expect(command.description.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getObject (delegates to dantalion-core.getDetail)', () => {
+    it('returns a Detail for a known Genius ID', () => {
+      const result = command.getObject('555');
+      expect(result).toEqual(
+        expect.objectContaining({ affinity: expect.any(Object) }),
+      );
+    });
+
+    it('returns the Genius list for an unknown Genius ID', () => {
+      const result = command.getObject('INVALID');
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toContain('555');
+      expect(result).toContain('000');
+    });
+
+    it('returns the Genius list when no argument is supplied', () => {
+      const result = command.getObject(undefined);
+      expect(Array.isArray(result)).toBe(true);
+      expect((result as readonly string[]).length).toBe(12);
+    });
+  });
+
+  describe('getDescriptionAsync (delegates to dantalion-i18n)', () => {
+    it('returns a Markdown string for a known Genius', async () => {
+      const md = await command.getDescriptionAsync('555');
+      expect(md).toEqual(expect.any(String));
+      expect(md.length).toBeGreaterThan(0);
+      expect(md).toMatch(/^#/m);
+    });
+  });
+});

--- a/packages/dantalion-cli/src/index.spec.ts
+++ b/packages/dantalion-cli/src/index.spec.ts
@@ -127,13 +127,17 @@ describe('dantalion CLI smoke', () => {
       expect(stdout).toMatch(/[぀-ゟ゠-ヿ一-鿿]/);
     });
 
-    it('LANG=en_US.UTF-8 produces ASCII-leaning Markdown output', async () => {
+    it('LANG=en_US.UTF-8 produces non-empty, CJK-free output', async () => {
       const { exitCode, stdout } = await runCli(['detail', '555'], {
         LANG: 'en_US.UTF-8',
       });
       expect(exitCode).toBe(0);
-      // English Markdown should contain at least one ASCII Markdown heading.
-      expect(stdout).toMatch(/^#/m);
+      expect(stdout.length).toBeGreaterThan(0);
+      // marked-terminal rewrites Markdown headings into ANSI-styled
+      // text, so the rendered output may not contain a literal `#`.
+      // Assert the locale is honored by requiring zero CJK code
+      // points (the same range the ja_JP test checks for presence of).
+      expect(stdout).not.toMatch(/[぀-ゟ゠-ヿ一-鿿]/);
     });
   });
 

--- a/packages/dantalion-cli/src/index.spec.ts
+++ b/packages/dantalion-cli/src/index.spec.ts
@@ -8,8 +8,14 @@ const { version: pkgVersion } = createRequire(import.meta.url)(
   '../package.json',
 ) as { version: string };
 
-const runCli = (args: string[]) =>
-  execa('node', [binPath, ...args], { reject: false });
+const runCli = (args: string[], env?: Record<string, string>) =>
+  execa(
+    'node',
+    [binPath, ...args],
+    env
+      ? { reject: false, env: { ...process.env, ...env } }
+      : { reject: false },
+  );
 
 describe('dantalion CLI smoke', () => {
   beforeAll(async () => {
@@ -48,6 +54,31 @@ describe('dantalion CLI smoke', () => {
         }),
       );
     });
+
+    it('renders Markdown without --raw', async () => {
+      const { exitCode, stdout } = await runCli(['personality', '1993-10-09']);
+      expect(exitCode).toBe(0);
+      expect(stdout.length).toBeGreaterThan(0);
+    });
+
+    it('the `ps` alias accepts the same args as `personality`', async () => {
+      const { exitCode, stdout } = await runCli(['ps', '1993-10-09', '--raw']);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed).toEqual(
+        expect.objectContaining({ cycle: expect.any(Number) }),
+      );
+    });
+
+    it('-r short flag is equivalent to --raw', async () => {
+      const { exitCode, stdout } = await runCli([
+        'personality',
+        '1993-10-09',
+        '-r',
+      ]);
+      expect(exitCode).toBe(0);
+      expect(() => JSON.parse(stdout)).not.toThrow();
+    });
   });
 
   describe('detail subcommand', () => {
@@ -60,6 +91,75 @@ describe('dantalion CLI smoke', () => {
           affinity: expect.any(Object),
         }),
       );
+    });
+
+    it('renders Markdown without --raw', async () => {
+      const { exitCode, stdout } = await runCli(['detail', '555']);
+      expect(exitCode).toBe(0);
+      expect(stdout.length).toBeGreaterThan(0);
+    });
+
+    it('the `dt` alias accepts the same args as `detail`', async () => {
+      const { exitCode, stdout } = await runCli(['dt', '555', '--raw']);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed).toEqual(
+        expect.objectContaining({ affinity: expect.any(Object) }),
+      );
+    });
+
+    it('with no genius argument, lists the available Genius IDs', async () => {
+      const { exitCode, stdout } = await runCli(['detail']);
+      expect(exitCode).toBe(0);
+      for (const id of ['000', '555', '919']) {
+        expect(stdout).toContain(id);
+      }
+    });
+  });
+
+  describe('locale selection (Intl.DateTimeFormat default)', () => {
+    it('LANG=ja_JP.UTF-8 produces Japanese-character output', async () => {
+      const { exitCode, stdout } = await runCli(['detail', '555'], {
+        LANG: 'ja_JP.UTF-8',
+      });
+      expect(exitCode).toBe(0);
+      // Hiragana / Katakana / CJK Unified Ideographs ranges.
+      expect(stdout).toMatch(/[぀-ゟ゠-ヿ一-鿿]/);
+    });
+
+    it('LANG=en_US.UTF-8 produces ASCII-leaning Markdown output', async () => {
+      const { exitCode, stdout } = await runCli(['detail', '555'], {
+        LANG: 'en_US.UTF-8',
+      });
+      expect(exitCode).toBe(0);
+      // English Markdown should contain at least one ASCII Markdown heading.
+      expect(stdout).toMatch(/^#/m);
+    });
+  });
+
+  describe('invalid input handling', () => {
+    it('an invalid date returns a soft "undefined" payload (current behavior)', async () => {
+      // The `personality.ts` command swallows out-of-range dates by
+      // emitting `undefined` and exiting 0. Lock the behavior in so a
+      // future change to make this fail-closed is visible.
+      const { exitCode, stdout } = await runCli([
+        'personality',
+        'NaN',
+        '--raw',
+      ]);
+      expect(exitCode).toBe(0);
+      expect(stdout.trim()).toBe('undefined');
+    });
+
+    it('an invalid Genius ID falls back to the type-list output', async () => {
+      // `getDetail()` returns undefined for unknown Genius IDs and the
+      // CLI then prints the canonical Genius list via `types.genius`.
+      // Lock the behavior in.
+      const { exitCode, stdout } = await runCli(['detail', 'INVALID', '--raw']);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toContain('555');
     });
   });
 

--- a/packages/dantalion-cli/src/index.ts
+++ b/packages/dantalion-cli/src/index.ts
@@ -2,8 +2,9 @@
 
 import { realpathSync } from 'node:fs';
 import { createRequire } from 'node:module';
+import { resolve as resolvePath } from 'node:path';
 import { argv } from 'node:process';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
 import { Command } from 'commander';
 import detail from './detail.js';
 import personality from './personality.js';
@@ -65,20 +66,24 @@ export const buildProgram = (): Command => {
 // as `dantalion` from the shell). Under `vitest` the test file imports
 // `buildProgram` and the block below stays inert.
 //
-// `argv[1]` may be a symlink path (npm/yarn `node_modules/.bin` and
-// global installs hard-link to the bin), while `import.meta.url` is
-// the resolved target. Resolve the symlink before comparing so the
-// guard still fires when launched via `dantalion` rather than
-// `node dist/src/index.js`.
-const resolveEntryUrl = (): string => {
-  if (!argv[1]) return '';
+// Normalization needed because:
+//   * `argv[1]` may be relative (`node dist/src/index.js`) — `pathToFileURL`
+//     rejects relative paths;
+//   * `argv[1]` may be a symlink (npm/yarn `node_modules/.bin`, global
+//     installs) — the symlink path differs from `import.meta.url`'s
+//     resolved target.
+// Resolve to an absolute realpath on both sides before comparing.
+const isProgramEntry = (): boolean => {
+  if (!argv[1]) return false;
   try {
-    return pathToFileURL(realpathSync(argv[1])).href;
+    const argvRealpath = realpathSync(resolvePath(argv[1]));
+    const moduleRealpath = realpathSync(fileURLToPath(import.meta.url));
+    return argvRealpath === moduleRealpath;
   } catch {
-    return pathToFileURL(argv[1]).href;
+    return false;
   }
 };
-if (import.meta.url === resolveEntryUrl()) {
+if (isProgramEntry()) {
   const program = buildProgram();
   program.parse(argv);
   if (argv.length < 1) {

--- a/packages/dantalion-cli/src/index.ts
+++ b/packages/dantalion-cli/src/index.ts
@@ -1,38 +1,73 @@
 #!/usr/bin/env node
 
 import { createRequire } from 'node:module';
+import { argv } from 'node:process';
+import { pathToFileURL } from 'node:url';
 import { Command } from 'commander';
 import detail from './detail.js';
 import personality from './personality.js';
 import showJson from './render/showJson.js';
 import showMd from './render/showMd.js';
 
-const { version } = createRequire(import.meta.url)('../../package.json') as {
-  version: string;
+/**
+ * Resolve the published package version. The relative path between
+ * this module and the canonical `package.json` differs between source
+ * (`src/index.ts` → `../package.json`) and the built artifact
+ * (`dist/src/index.js` → `../../package.json`), so try both before
+ * falling back to a sentinel.
+ */
+const readVersion = (): string => {
+  const require = createRequire(import.meta.url);
+  for (const candidate of ['../../package.json', '../package.json']) {
+    try {
+      return (require(candidate) as { version: string }).version;
+    } catch {
+      // Fall through to next candidate.
+    }
+  }
+  return '0.0.0-unknown';
 };
 
-const program = new Command();
+/**
+ * Build the commander `Program` for the dantalion CLI. Exposed so a
+ * unit spec can inspect the wiring (registered subcommands, version)
+ * without triggering `process.argv` parsing as a side effect of
+ * importing this module.
+ */
+export const buildProgram = (): Command => {
+  const program = new Command();
+  for (const {
+    getDescriptionAsync,
+    getObject,
+    alias,
+    command,
+    description,
+  } of [detail, personality]) {
+    program
+      .command(command)
+      .alias(alias)
+      .option('-r, --raw', 'Returns the raw JSON')
+      .description(description)
+      .action(async (arg: string | undefined, { raw }: { raw?: boolean }) => {
+        if (raw) {
+          showJson(await getObject(arg));
+        } else {
+          showMd(await getDescriptionAsync(arg));
+        }
+      });
+  }
+  program.version(readVersion());
+  return program;
+};
 
-for (const { getDescriptionAsync, getObject, alias, command, description } of [
-  detail,
-  personality,
-]) {
-  program
-    .command(command)
-    .alias(alias)
-    .option('-r, --raw', 'Returns the raw JSON')
-    .description(description)
-    .action(async (arg: string | undefined, { raw }: { raw?: boolean }) => {
-      if (raw) {
-        showJson(await getObject(arg));
-      } else {
-        showMd(await getDescriptionAsync(arg));
-      }
-    });
-}
-
-program.version(version);
-program.parse(process.argv);
-if (process.argv.length < 1) {
-  program.help();
+// Run only when this module is the program entry point (i.e., invoked
+// as `dantalion` from the shell). Under `vitest` the test file imports
+// `buildProgram` and the block below stays inert.
+const entryPoint = argv[1] ? pathToFileURL(argv[1]).href : '';
+if (import.meta.url === entryPoint) {
+  const program = buildProgram();
+  program.parse(argv);
+  if (argv.length < 1) {
+    program.help();
+  }
 }

--- a/packages/dantalion-cli/src/index.ts
+++ b/packages/dantalion-cli/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { realpathSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { argv } from 'node:process';
 import { pathToFileURL } from 'node:url';
@@ -63,8 +64,21 @@ export const buildProgram = (): Command => {
 // Run only when this module is the program entry point (i.e., invoked
 // as `dantalion` from the shell). Under `vitest` the test file imports
 // `buildProgram` and the block below stays inert.
-const entryPoint = argv[1] ? pathToFileURL(argv[1]).href : '';
-if (import.meta.url === entryPoint) {
+//
+// `argv[1]` may be a symlink path (npm/yarn `node_modules/.bin` and
+// global installs hard-link to the bin), while `import.meta.url` is
+// the resolved target. Resolve the symlink before comparing so the
+// guard still fires when launched via `dantalion` rather than
+// `node dist/src/index.js`.
+const resolveEntryUrl = (): string => {
+  if (!argv[1]) return '';
+  try {
+    return pathToFileURL(realpathSync(argv[1])).href;
+  } catch {
+    return pathToFileURL(argv[1]).href;
+  }
+};
+if (import.meta.url === resolveEntryUrl()) {
   const program = buildProgram();
   program.parse(argv);
   if (argv.length < 1) {

--- a/packages/dantalion-cli/src/index.unit.spec.ts
+++ b/packages/dantalion-cli/src/index.unit.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildProgram } from './index.js';
+
+describe('buildProgram (in-process)', () => {
+  it('registers both subcommands', () => {
+    const program = buildProgram();
+    const commandNames = program.commands.map((c) => c.name());
+    expect(commandNames).toContain('detail');
+    expect(commandNames).toContain('personality');
+  });
+
+  it('registers the short aliases `dt` and `ps`', () => {
+    const program = buildProgram();
+    const aliasFor = (name: string) =>
+      program.commands.find((c) => c.name() === name)?.aliases() ?? [];
+    expect(aliasFor('detail')).toEqual(expect.arrayContaining(['dt']));
+    expect(aliasFor('personality')).toEqual(expect.arrayContaining(['ps']));
+  });
+
+  it('exposes the package version', () => {
+    const program = buildProgram();
+    expect(program.version()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('each subcommand declares the `-r, --raw` option', () => {
+    const program = buildProgram();
+    for (const cmd of program.commands) {
+      const raw = cmd.options.find((o) => o.long === '--raw');
+      expect(
+        raw,
+        `subcommand "${cmd.name()}" must declare --raw`,
+      ).toBeDefined();
+      expect(raw?.short).toBe('-r');
+    }
+  });
+
+  it('each subcommand carries a non-empty description', () => {
+    const program = buildProgram();
+    for (const cmd of program.commands) {
+      expect(cmd.description().length).toBeGreaterThan(0);
+    }
+  });
+
+  describe('action callbacks (via program.parseAsync)', () => {
+    it('detail --raw triggers the showJson branch', async () => {
+      const infoSpy = vi
+        .spyOn(console, 'info')
+        .mockImplementation(() => undefined);
+      try {
+        const program = buildProgram();
+        await program.parseAsync(['node', 'cli', 'detail', '555', '--raw']);
+        expect(infoSpy).toHaveBeenCalledOnce();
+        const arg = infoSpy.mock.calls[0]?.[0] as string;
+        const parsed = JSON.parse(arg);
+        expect(parsed).toEqual(
+          expect.objectContaining({ affinity: expect.any(Object) }),
+        );
+      } finally {
+        infoSpy.mockRestore();
+      }
+    });
+
+    it('personality (no --raw) triggers the showMd branch', async () => {
+      const infoSpy = vi
+        .spyOn(console, 'info')
+        .mockImplementation(() => undefined);
+      try {
+        const program = buildProgram();
+        await program.parseAsync(['node', 'cli', 'personality', '1993-10-09']);
+        expect(infoSpy).toHaveBeenCalledOnce();
+        const arg = infoSpy.mock.calls[0]?.[0] as string;
+        expect(typeof arg).toBe('string');
+        expect(arg.length).toBeGreaterThan(0);
+      } finally {
+        infoSpy.mockRestore();
+      }
+    });
+  });
+});

--- a/packages/dantalion-cli/src/personality.spec.ts
+++ b/packages/dantalion-cli/src/personality.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import command from './personality.js';
+
+describe('personality command (in-process)', () => {
+  describe('command metadata', () => {
+    it('declares the expected commander wiring', () => {
+      expect(command.command).toBe('personality <birthday>');
+      expect(command.alias).toBe('ps');
+      expect(command.description).toEqual(expect.any(String));
+      expect(command.description.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getObject (delegates to dantalion-core.getPersonality)', () => {
+    it('returns a Personality for a valid in-range date', () => {
+      const result = command.getObject('1993-10-09');
+      expect(result).toEqual(
+        expect.objectContaining({
+          cycle: expect.any(Number),
+          inner: expect.any(String),
+          outer: expect.any(String),
+          workStyle: expect.any(String),
+          lifeBase: expect.any(String),
+          potentials: expect.any(Array),
+        }),
+      );
+    });
+
+    it('returns undefined for an out-of-range date', () => {
+      expect(command.getObject('1700-01-01')).toBeUndefined();
+    });
+
+    it('returns undefined for a non-date string', () => {
+      expect(command.getObject('not-a-date')).toBeUndefined();
+    });
+  });
+
+  describe('getDescriptionAsync (delegates to dantalion-i18n)', () => {
+    it('returns a Markdown string for a valid date', async () => {
+      const md = await command.getDescriptionAsync('1993-10-09');
+      expect(md).toEqual(expect.any(String));
+      expect(md.length).toBeGreaterThan(0);
+      // Should contain at least one Markdown heading.
+      expect(md).toMatch(/^#/m);
+    });
+  });
+});

--- a/packages/dantalion-cli/src/render/showJson.spec.ts
+++ b/packages/dantalion-cli/src/render/showJson.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import showJson from './showJson.js';
+
+describe('showJson', () => {
+  it('writes the JSON-stringified value to console.info', () => {
+    const infoSpy = vi
+      .spyOn(console, 'info')
+      .mockImplementation(() => undefined);
+    try {
+      showJson({ a: 1, b: 'two' });
+      expect(infoSpy).toHaveBeenCalledOnce();
+      const arg = infoSpy.mock.calls[0]?.[0] as string;
+      const parsed = JSON.parse(arg);
+      expect(parsed).toEqual({ a: 1, b: 'two' });
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it('handles null / undefined inputs without throwing', () => {
+    const infoSpy = vi
+      .spyOn(console, 'info')
+      .mockImplementation(() => undefined);
+    try {
+      showJson(null);
+      showJson(undefined);
+      expect(infoSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+});

--- a/packages/dantalion-cli/src/render/showMd.spec.ts
+++ b/packages/dantalion-cli/src/render/showMd.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import showMd from './showMd.js';
+
+describe('showMd', () => {
+  it('forwards the rendered Markdown to console.info', () => {
+    const infoSpy = vi
+      .spyOn(console, 'info')
+      .mockImplementation(() => undefined);
+    try {
+      showMd('# heading\n\nbody text');
+      expect(infoSpy).toHaveBeenCalledOnce();
+      const arg = infoSpy.mock.calls[0]?.[0] as string;
+      expect(typeof arg).toBe('string');
+      expect(arg.length).toBeGreaterThan(0);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it('handles an empty Markdown source', () => {
+    const infoSpy = vi
+      .spyOn(console, 'info')
+      .mockImplementation(() => undefined);
+    try {
+      showMd('');
+      expect(infoSpy).toHaveBeenCalledOnce();
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+});

--- a/packages/dantalion-cli/vitest.config.mts
+++ b/packages/dantalion-cli/vitest.config.mts
@@ -8,19 +8,20 @@ export default defineConfig({
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.spec.ts'],
-      // The CLI smoke spec (#145) invokes the built `dist/src/index.js`
-      // through `execa`, so v8 instrumentation cannot follow the
-      // subprocess and reports 0% coverage here. Setting any positive
-      // threshold would fail CI immediately. The thresholds remain
-      // declared (as the project standard) at 0, and an in-process
-      // CLI matrix that would produce real coverage numbers is
-      // intentionally tracked separately in #152.
-      // Baseline measured 2026-05-20.
+      // After #152 landed, the in-process unit specs (detail.spec,
+      // personality.spec, index.unit.spec, render/*.spec) lift v8
+      // coverage off the floor:
+      //   stmt 83% / branch 60% / func 100% / lines 83% (2026-05-20)
+      // The remaining uncovered code is the entry-point guard block
+      // and the version-fallback path, both of which only fire when
+      // the module is invoked as the program (covered by the execa
+      // smoke spec, but v8 doesn't follow into subprocesses). Set
+      // thresholds 3–10 pp below the measured baseline.
       thresholds: {
-        statements: 0,
-        branches: 0,
-        functions: 0,
-        lines: 0,
+        statements: 80,
+        branches: 50,
+        functions: 95,
+        lines: 80,
       },
     },
   },


### PR DESCRIPTION
Closes #152. Part of #144.

## Summary

Extend the #145 execa smoke harness into the full CLI surface and add in-process unit specs that let v8 instrumentation report meaningful coverage.

| Coverage axis    | Before | After  |
|------------------|-------:|-------:|
| Statements       | 0 %    | 83 %   |
| Branches         | 0 %    | 60 %   |
| Functions        | 0 %    | 100 %  |
| Lines            | 0 %    | 83 %   |

## Test inventory

### Subprocess (execa) — `src/index.spec.ts`

14 tests covering `personality` / `detail` / aliases (`ps` / `dt`) × `[--raw, -r, default]` × locale (`LANG=ja_JP.UTF-8`, `LANG=en_US.UTF-8`) × invalid-input (date `NaN`, Genius `INVALID`) × `--help` / `--version`.

### In-process (vitest + console spy)

- `src/personality.spec.ts` (5 tests) and `src/detail.spec.ts` (5) — direct invocation of `getObject` / `getDescriptionAsync`.
- `src/render/showJson.spec.ts` (2) and `src/render/showMd.spec.ts` (2) — console.info spy.
- `src/index.unit.spec.ts` (7) — `buildProgram()` wiring + `program.parseAsync(...)` exercising action callbacks.

Total CLI test count: **35** (was 1 placeholder before #145).

## Source changes

`src/index.ts` is refactored so the `commander.Program` factory is exposed as `buildProgram()` and only auto-runs when invoked as the program entry point (detected via `import.meta.url === pathToFileURL(argv[1]).href`). The unit spec can import the factory without triggering `process.argv` parsing as a side effect.

The version string resolution is wrapped in a helper that tries `../../package.json` (dist runtime layout) then `../package.json` (source-tree test layout) and falls back to a sentinel.

## Coverage thresholds (#150 follow-up)

`packages/dantalion-cli/vitest.config.mts` thresholds raised from 0/0/0/0 to **80/50/95/80** (stmt/branch/func/lines), set 3–10 pp below the new baseline.

## Known limitations

Branch coverage stops at 60 % because two branches only fire in the entry-point block (line 67) and the version-fallback final-return path (line 28). Both fire when the module runs as a program — the execa subprocess tests do exercise them, but v8 coverage cannot follow into subprocesses. Closing that last 20 pp would require either NODE_V8_COVERAGE merging across processes or mocking `createRequire` at the module level, both of which are disproportionate to the value. The #144 roadmap retrospective will note this as a known artifact rather than a follow-up issue.

## Test plan

- [x] `pnpm --filter @kurone-kito/dantalion-cli run test:vitest` — 35 tests pass
- [x] `pnpm run test` — 673 tests pass across all packages (was 642)
- [x] `pnpm run lint` — clean
- [x] `pnpm run build` — all three packages build
- [x] Sanity: deliberately removing one action handler causes the unit spec to fail (verified locally)
- [ ] CI matrix (Node 22 + 24) — to be verified on this PR