### PR TITLE
ci: add Stryker mutation-testing job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,22 @@ jobs:
           HUSKY: 0
         run: pnpm install --frozen-lockfile --prefer-offline
       - run: pnpm run build
+
+  mutation:
+    name: mutation
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      - env:
+          HUSKY: 0
+        run: pnpm install --frozen-lockfile --prefer-offline
+      - run: pnpm --filter @kurone-kito/dantalion-core run test:mutation


### PR DESCRIPTION
## Summary

- Adds a `mutation` job to `.github/workflows/ci.yml` that runs Stryker mutation testing on `dantalion-core` for every `pull_request` event.

## Design decisions

- **`pull_request` only, not `push`**: avoids doubling CI cost on merge commits. The mutation score of `main` is implied by the last merged PR's run.
- **Single Node version** (`.node-version` = Node 22 LTS): mutation testing on a full matrix would be wasteful since Stryker tests the compiled logic, not Node-version-specific behavior.
- **`timeout-minutes: 15`**: the #151 trial baseline was 1m47s at concurrency 2; 15 min is a comfortable safety margin for slower CI runners.
- **NOT added to `required_status_checks`**: baking first per the #160 retrospective. Promote in a follow-up PR after observing stability.

## Baseline from #151 trial

| Metric | Value |
|---|---|
| Mutation score | 93.41 % |
| Wall-clock | 1m47s |
| Survivors | 6 (5 in createGeniusRecord/createGeniusRecords, 1 in getFactors:54) |

PRs #164 / #165 (part of roadmap #160) add direct unit tests for the 5 factory survivors and document why the getFactors:54 survivor is an equivalent mutant that cannot be killed. After those merge, the score should approach ~100 % (minus the equivalent mutant).

## Test plan

- [x] `pnpm run lint` — clean
- [ ] CI passes on this PR (mutation job itself runs on the PR and reports the score)
- [ ] mutation job wall-clock within 15 min timeout

The mutation job will run on this PR itself, providing the first CI-observed score for comparison against the #151 baseline.

Closes #161. Part of #160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)