### PR TITLE
docs: link the live web demo URL alongside the source repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,8 @@ minimum project rules immediately. The canonical full guide lives in
 
 Cross-package dependency direction: `core ← i18n ← cli`.
 The former web playground has been split out to
-[`kurone-kito/dantalion-web-demo`](https://github.com/kurone-kito/dantalion-web-demo).
+[`kurone-kito/dantalion-web-demo`](https://github.com/kurone-kito/dantalion-web-demo)
+and is published live at <https://kurone-kito.github.io/dantalion/>.
 
 ## IDD workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,8 @@ strictly `core → i18n → cli` (issues #87 → #88 → #89).
 
 The browser-facing web demo lives in its own repository,
 [`kurone-kito/dantalion-web-demo`](https://github.com/kurone-kito/dantalion-web-demo),
-and is no longer part of this monorepo.
+and is no longer part of this monorepo. It is published live at
+<https://kurone-kito.github.io/dantalion/>.
 
 ## Commit rules
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -49,7 +49,8 @@ The canonical full guide lives in
 
 Cross-package dependency direction: `core ← i18n ← cli`.
 The former web playground has been split out to
-[`kurone-kito/dantalion-web-demo`](https://github.com/kurone-kito/dantalion-web-demo).
+[`kurone-kito/dantalion-web-demo`](https://github.com/kurone-kito/dantalion-web-demo)
+and is published live at <https://kurone-kito.github.io/dantalion/>.
 
 ## IDD workflow
 

--- a/README.md
+++ b/README.md
@@ -88,8 +88,12 @@ notes.
 
 ## Web demo
 
-The browser-facing playground lives in its own repository:
-[`kurone-kito/dantalion-web-demo`](https://github.com/kurone-kito/dantalion-web-demo).
+Try it live: <https://kurone-kito.github.io/dantalion/>.
+
+The browser-facing playground lives in its own repository,
+[`kurone-kito/dantalion-web-demo`](https://github.com/kurone-kito/dantalion-web-demo),
+which consumes the modernized `v1.0.0-rc.x` line of the published
+packages and redeploys to the URL above on every push to its `main`.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Surface the live demo URL `https://kurone-kito.github.io/dantalion/`
alongside the existing source-repo pointer to
`kurone-kito/dantalion-web-demo`.

The `dantalion-web-demo` roadmap closed this week (all 12 child issues
merged, cross-repo deploy verified end-to-end), so this repository's
public-facing docs can now safely send readers to the running deploy
instead of only to the source repo.

## What changed

- `README.md` — adds a `Try it live:` line at the top of the `## Web demo`
  section and a one-sentence note that the demo consumes the
  `v1.0.0-rc.x` line and redeploys on every push.
- `AGENTS.md`, `GEMINI.md` — single-sentence append to the existing
  cross-package paragraph so the live URL appears in the table-of-contents
  bullet about the split-out repository.
- `CLAUDE.md` — same single-sentence append to the
  `web demo lives in its own repository ...` block under
  `## Package responsibilities` (different position from
  AGENTS.md / GEMINI.md, so kept the edit in its own block).

No package metadata (`package.json` `homepage` etc.) was changed — those
intentionally point at the canonical GitHub README, not at the demo
deployment, so they stay as-is.

## Test plan

- [x] `pnpm run lint` exits zero (cspell, biome, markdownlint via
      `lint-staged` pre-commit also re-checked the staged files)
- [ ] CI green — verified post-merge

Refs: dantalion-web-demo roadmap [#2](https://github.com/kurone-kito/dantalion-web-demo/issues/2) close-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation across multiple files with improved formatting and clearer references to live demo links.
  * Enhanced the "Web demo" section with a direct "Try it live" link and expanded description of the browser-facing playground.
  * Made links to published demo sites more prominent and accessible throughout the documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->