### PR TITLE
feat(core): add HeavenlyStem literal-union type and apply to cycle

### DIFF
--- a/packages/dantalion-core/src/index.ts
+++ b/packages/dantalion-core/src/index.ts
@@ -7,6 +7,7 @@ export type { AffinityLevel } from './types/AffinityLevel.js';
 export type { Brain } from './types/brain.js';
 export type { Communication } from './types/communication.js';
 export type { Genius } from './types/genius.js';
+export type { HeavenlyStem } from './types/heavenlyStem.js';
 export type { AllTypes } from './types/index.js';
 export { default as types } from './types/index.js';
 export type { LifeBase } from './types/lifeBase.js';

--- a/packages/dantalion-core/src/types/heavenlyStem.ts
+++ b/packages/dantalion-core/src/types/heavenlyStem.ts
@@ -1,0 +1,20 @@
+/**
+ * The heavenly stem (天干, Tian Gan) — the ten-phase sub-personality cycle.
+ *
+ * | Value | Stem |
+ * | :---: | :--: |
+ * |   1   |  甲  |
+ * |   2   |  乙  |
+ * |   3   |  丙  |
+ * |   4   |  丁  |
+ * |   5   |  戊  |
+ * |   6   |  己  |
+ * |   7   |  庚  |
+ * |   8   |  辛  |
+ * |   9   |  壬  |
+ * |  10   |  癸  |
+ */
+export type HeavenlyStem = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
+
+/** The list of heavenly stem values. */
+export default Object.freeze<HeavenlyStem[]>([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);

--- a/packages/dantalion-core/src/utils/getFactors.ts
+++ b/packages/dantalion-core/src/utils/getFactors.ts
@@ -1,3 +1,4 @@
+import type { HeavenlyStem } from '../types/heavenlyStem.js';
 import assertDefined from './assertDefined.js';
 import type { Source2D } from './create2DAccessor.js';
 import type { BirthdayDetails } from './getBirthdayDetails.js';
@@ -6,7 +7,7 @@ import shiftAndModulo from './shiftAndModulo.js';
 /** Intermediate values that determine the factors of personality. */
 export interface Factors {
   /** The factors that determine the sub-personality (cycle). */
-  cycle: number;
+  cycle: HeavenlyStem;
   /** Gets the coordinates of the table. */
   getXY: (value: number) => Source2D;
   /** The factors that determine the inner personality. */
@@ -49,7 +50,7 @@ export default (source: FactorSource): Factors => {
     shiftAndModulo(v, 10),
   );
   return {
-    cycle: shiftAndModulo(cycle, 10),
+    cycle: shiftAndModulo(cycle, 10) as HeavenlyStem,
     getXY: (value: number): Source2D => ({ x: value - 1, y: cycle % 10 }),
     inner: shiftAndModulo(shifted * 6 + hi * 4 + cycle - 6, 12),
     lifeBase: date - monthlyCoefficients,

--- a/packages/dantalion-core/src/utils/getPersonality.ts
+++ b/packages/dantalion-core/src/utils/getPersonality.ts
@@ -4,6 +4,7 @@ import lifeBaseCoefficients from '../records/lifeBaseCoefficients.js';
 import lifeBaseTable from '../records/lifeBaseTable.js';
 import potentialTable from '../records/potentialTable.js';
 import type { Genius } from '../types/genius.js';
+import type { HeavenlyStem } from '../types/heavenlyStem.js';
 import type { LifeBase } from '../types/lifeBase.js';
 import type { Potential } from '../types/potential.js';
 import assertDefined from './assertDefined.js';
@@ -13,7 +14,7 @@ import getFactors from './getFactors.js';
 /** The details for Personality. */
 export interface Personality {
   /** The sub-personality (cycle). */
-  cycle: number;
+  cycle: HeavenlyStem;
   /** The inner personality. */
   inner: Genius;
   /** The life base. */

--- a/packages/dantalion-core/src/utils/toCC.spec.ts
+++ b/packages/dantalion-core/src/utils/toCC.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { HeavenlyStem } from '../types/heavenlyStem.js';
 import type { Personality } from './getPersonality.js';
 import toCC from './toCC.js';
 
@@ -27,7 +28,7 @@ describe('toCC', () => {
     expect(cc.split('-')[3]).toBe('8880');
   });
 
-  it.each<[number, string]>([
+  it.each<[HeavenlyStem, string]>([
     [1, '1'],
     [2, '2'],
     [5, '5'],


### PR DESCRIPTION
## Summary

Introduces `HeavenlyStem = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10` as a dedicated type for the `cycle` property in `dantalion-core`, making it consistent with every other personality parameter which already uses a narrow literal-union type.

- New `types/heavenlyStem.ts` — exports `HeavenlyStem` type and frozen values array, following the `genius.ts` / `lifeBase.ts` pattern
- `Factors.cycle` and `Personality.cycle` narrowed from `number` to `HeavenlyStem`
- `shiftAndModulo(cycle, 10) as HeavenlyStem` assertion in `getFactors.ts` (safe: `shiftAndModulo` always returns [1, n])
- `HeavenlyStem` exported from the package public API
- `toCC.spec.ts` generic parameter updated from `[number, string]` to `[HeavenlyStem, string]` to match the narrowed type

No runtime behaviour changes. `toCC.ts` `cycle % 10` continues to return `number` (TypeScript arithmetic is not narrowed), so no further edits are required there.

Closes #169

## Test plan

- [x] `pnpm run lint` — no new errors (4 pre-existing biome warnings unrelated to this PR)
- [x] `pnpm run test` — 20 test files, 872 tests, all pass
- [x] `pnpm run build` — TypeScript build clean across all 3 packages

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exported HeavenlyStem type from the public API, representing numeric values 1–10 with reference data.

* **Refactor**
  * Enhanced core utility types to use HeavenlyStem for cycle fields, replacing generic numeric types for improved type precision and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->