### PR TITLE
fix(schema): correct cycle maximum from 11 to 10

### DIFF
--- a/schema/personality.schema.json
+++ b/schema/personality.schema.json
@@ -45,7 +45,7 @@
     "cycle": {
       "type": "integer",
       "minimum": 1,
-      "maximum": 11
+      "maximum": 10
     },
     "inner": {
       "$ref": "#/definitions/genius"


### PR DESCRIPTION
## Summary

Fixes an off-by-one in `schema/personality.schema.json`: `cycle` had `"maximum": 11` but the valid range is [1, 10] (十干). The value 11 was incorrectly allowed through schema validation.

- `schema/personality.schema.json`: `"maximum": 11` → `"maximum": 10`

Closes #170

## Test plan

- [x] `pnpm run lint` — no errors
- [x] `pnpm run test` — 872 tests pass
- [x] `pnpm run build` — TypeScript build clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the maximum cycle constraint value.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->